### PR TITLE
Added html5 targetOptions for index template and debugIndexTemplate

### DIFF
--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -69,13 +69,23 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
             if (this.isDebugHtml5()) {
                 let index = path.join(this.options.to, this.sysdir(), 'index.html');
-                if (!fs.existsSync(index)) {
-                    let protoindex = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'index.html'), { encoding: 'utf8' });
+                var protoindex;
+                
+                if(targetOptions.html5.debugIndexTemplate !== undefined) {
+                    protoindex = fs.readFileSync(path.resolve(this.options.from, targetOptions.html5.debugIndexTemplate), { encoding: 'utf8' });
+                } else {
+                    if (!fs.existsSync(index)) {
+                        protoindex = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'index.html'), { encoding: 'utf8' });
+                    }
+                }
+                
+                if (protoindex !== undefined) {
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);
                     fs.writeFileSync(index.toString(), protoindex);
                 }
+                
                 let pack = path.join(this.options.to, this.sysdir(), 'package.json');
                 let protopackage = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'package.json'), { encoding: 'utf8' });
                 protopackage = protopackage.replace(/{Name}/g, name);
@@ -96,8 +106,17 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             }
             else {
                 let index = path.join(this.options.to, this.sysdir(), 'index.html');
-                if (!fs.existsSync(index)) {
-                    let protoindex = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'html5', 'index.html'), { encoding: 'utf8' });
+                var protoindex;
+                
+                if(targetOptions.html5.indexTemplate !== undefined) {
+                    protoindex = fs.readFileSync(path.resolve(this.options.from, targetOptions.html5.indexTemplate), { encoding: 'utf8' });
+                } else {
+                    if (!fs.existsSync(index)) {
+                        protoindex = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'html5', 'index.html'), { encoding: 'utf8' });
+                    }
+                }
+                
+                if(protoindex !== undefined){
                     protoindex = protoindex.replace(/{Name}/g, name);
                     protoindex = protoindex.replace(/{Width}/g, '' + this.width);
                     protoindex = protoindex.replace(/{Height}/g, '' + this.height);


### PR DESCRIPTION
You can now add stuff like this to khafile.js:

    project.targetOptions.html5.indexTemplate = 'Templates/index.html';
    project.targetOptions.html5.debugIndexTemplate = 'Templates/index.html';

These files will be used when building. This way you no longer have to manually go into the html build folder and make changes manually after building.