### PR TITLE
Support absolute library paths

### DIFF
--- a/out/Project.js
+++ b/out/Project.js
@@ -92,6 +92,10 @@ class Project {
         this.addDefine(library);
         let self = this;
         function findLibraryDirectory(name) {
+            if (path.isAbsolute(name)) {
+                var dirs = name.split('/');
+                return { libpath: name, libroot: dirs[dirs.length - 1] };
+            }
             // Tries to load the default library from inside the kha project.
             // e.g. 'Libraries/wyngine'
             let libpath = path.join(self.scriptdir, self.localLibraryPath, name);

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -124,6 +124,10 @@ export class Project {
 		this.addDefine(library);
 		let self = this;
 		function findLibraryDirectory(name: string) {
+			if (path.isAbsolute(name)) {
+				var dirs = name.split('/');
+				return { libpath: name, libroot: dirs[dirs.length - 1] };
+			}
 			// Tries to load the default library from inside the kha project.
 			// e.g. 'Libraries/wyngine'
 			let libpath = path.join(self.scriptdir, self.localLibraryPath, name);


### PR DESCRIPTION
Adds support for adding library using absolute path in khafile.js

`project.addLibrary("/Users/lubos/Documents/mylib");`