### PR TITLE
Fix korefiles when using absolute library path

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -2,16 +2,17 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs');
-const path = require('path');
-const log = require('./log');
-const chokidar = require('chokidar');
-const crypto = require('crypto');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const path = require("path");
+const log = require("./log");
+const chokidar = require("chokidar");
+const crypto = require("crypto");
 class AssetConverter {
     constructor(exporter, platform, assetMatchers) {
         this.exporter = exporter;

--- a/out/Color.js
+++ b/out/Color.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 class Color {
 }
 exports.Color = Color;

--- a/out/Converter.js
+++ b/out/Converter.js
@@ -1,6 +1,7 @@
 "use strict";
-const child_process = require('child_process');
-const fs = require('fs');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs");
 function convert(inFilename, outFilename, encoder, args = null) {
     return new Promise((resolve, reject) => {
         if (fs.existsSync(outFilename.toString()) && fs.statSync(outFilename.toString()).mtime.getTime() > fs.statSync(inFilename.toString()).mtime.getTime()) {

--- a/out/Exporters/AndroidExporter.js
+++ b/out/Exporters/AndroidExporter.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const ImageTool_1 = require("../ImageTool");
 function findIcon(from, options) {
     if (fs.existsSync(path.join(from, 'icon.png')))
         return path.join(from, 'icon.png');

--- a/out/Exporters/CSharpExporter.js
+++ b/out/Exporters/CSharpExporter.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const ImageTool_1 = require("../ImageTool");
 const uuid = require('uuid');
 class CSharpExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {

--- a/out/Exporters/DebugHtml5Exporter.js
+++ b/out/Exporters/DebugHtml5Exporter.js
@@ -1,5 +1,6 @@
 "use strict";
-const Html5Exporter_1 = require('./Html5Exporter');
+Object.defineProperty(exports, "__esModule", { value: true });
+const Html5Exporter_1 = require("./Html5Exporter");
 class DebugHtml5Exporter extends Html5Exporter_1.Html5Exporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/EmptyExporter.js
+++ b/out/Exporters/EmptyExporter.js
@@ -2,17 +2,18 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const child_process = require('child_process');
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Haxe_1 = require('../Haxe');
-const log = require('../log');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Haxe_1 = require("../Haxe");
+const log = require("../log");
 class EmptyExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/Exporter.js
+++ b/out/Exporters/Exporter.js
@@ -1,5 +1,6 @@
 "use strict";
-const fs = require('fs-extra');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
 class Exporter {
     constructor() {
     }

--- a/out/Exporters/FlashExporter.js
+++ b/out/Exporters/FlashExporter.js
@@ -2,16 +2,17 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Converter_1 = require('../Converter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Converter_1 = require("../Converter");
+const ImageTool_1 = require("../ImageTool");
 function adjustFilename(filename) {
     filename = filename.replace(/\./g, '_');
     filename = filename.replace(/-/g, '_');

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -2,16 +2,17 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Converter_1 = require('../Converter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Converter_1 = require("../Converter");
+const ImageTool_1 = require("../ImageTool");
 class Html5Exporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/Html5WorkerExporter.js
+++ b/out/Exporters/Html5WorkerExporter.js
@@ -1,6 +1,7 @@
 "use strict";
-const path = require('path');
-const Html5Exporter_1 = require('./Html5Exporter');
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
+const Html5Exporter_1 = require("./Html5Exporter");
 class Html5WorkerExporter extends Html5Exporter_1.Html5Exporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/JavaExporter.js
+++ b/out/Exporters/JavaExporter.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const ImageTool_1 = require("../ImageTool");
 class JavaExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/KhaExporter.js
+++ b/out/Exporters/KhaExporter.js
@@ -2,13 +2,14 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const path = require('path');
-const Exporter_1 = require('./Exporter');
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
+const Exporter_1 = require("./Exporter");
 class KhaExporter extends Exporter_1.Exporter {
     constructor(options) {
         super();

--- a/out/Exporters/KoreExporter.js
+++ b/out/Exporters/KoreExporter.js
@@ -2,17 +2,18 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Converter_1 = require('../Converter');
-const Platform_1 = require('../Platform');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Converter_1 = require("../Converter");
+const Platform_1 = require("../Platform");
+const ImageTool_1 = require("../ImageTool");
 class KoreExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/KoreHLExporter.js
+++ b/out/Exporters/KoreHLExporter.js
@@ -2,17 +2,18 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Converter_1 = require('../Converter');
-const Platform_1 = require('../Platform');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Converter_1 = require("../Converter");
+const Platform_1 = require("../Platform");
+const ImageTool_1 = require("../ImageTool");
 class KoreHLExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/KromExporter.js
+++ b/out/Exporters/KromExporter.js
@@ -2,16 +2,17 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Converter_1 = require('../Converter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Converter_1 = require("../Converter");
+const ImageTool_1 = require("../ImageTool");
 class KromExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/NodeExporter.js
+++ b/out/Exporters/NodeExporter.js
@@ -1,6 +1,7 @@
 "use strict";
-const path = require('path');
-const Html5Exporter_1 = require('./Html5Exporter');
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
+const Html5Exporter_1 = require("./Html5Exporter");
 class NodeExporter extends Html5Exporter_1.Html5Exporter {
     constructor(options) {
         super(options);

--- a/out/Exporters/PlayStationMobileExporter.js
+++ b/out/Exporters/PlayStationMobileExporter.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const CSharpExporter_1 = require('./CSharpExporter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const CSharpExporter_1 = require("./CSharpExporter");
+const ImageTool_1 = require("../ImageTool");
 const uuid = require('uuid');
 class PlayStationMobileExporter extends CSharpExporter_1.CSharpExporter {
     constructor(options) {

--- a/out/Exporters/UnityExporter.js
+++ b/out/Exporters/UnityExporter.js
@@ -2,16 +2,17 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const KhaExporter_1 = require('./KhaExporter');
-const Converter_1 = require('../Converter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const KhaExporter_1 = require("./KhaExporter");
+const Converter_1 = require("../Converter");
+const ImageTool_1 = require("../ImageTool");
 const uuid = require('uuid');
 class UnityExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {

--- a/out/Exporters/WpfExporter.js
+++ b/out/Exporters/WpfExporter.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const CSharpExporter_1 = require('./CSharpExporter');
-const Converter_1 = require('../Converter');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const CSharpExporter_1 = require("./CSharpExporter");
+const Converter_1 = require("../Converter");
 const uuid = require('uuid');
 class WpfExporter extends CSharpExporter_1.CSharpExporter {
     constructor(options) {

--- a/out/Exporters/XnaExporter.js
+++ b/out/Exporters/XnaExporter.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs-extra');
-const path = require('path');
-const CSharpExporter_1 = require('./CSharpExporter');
-const ImageTool_1 = require('../ImageTool');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const CSharpExporter_1 = require("./CSharpExporter");
+const ImageTool_1 = require("../ImageTool");
 const uuid = require('uuid');
 function findIcon(from, options) {
     if (fs.existsSync(path.join(from, 'icon.png')))

--- a/out/GraphicsApi.js
+++ b/out/GraphicsApi.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.GraphicsApi = {
     OpenGL: 'opengl',
     OpenGL2: 'opengl2',

--- a/out/Haxe.js
+++ b/out/Haxe.js
@@ -1,9 +1,10 @@
 "use strict";
-const child_process = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const log = require('./log');
-const exec_1 = require('./exec');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const log = require("./log");
+const exec_1 = require("./exec");
 function executeHaxe(from, haxeDirectory, options) {
     return new Promise((resolve, reject) => {
         let exe = 'haxe';

--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -2,17 +2,18 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const child_process = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const chokidar = require('chokidar');
-const log = require('./log');
-const exec_1 = require('./exec');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const chokidar = require("chokidar");
+const log = require("./log");
+const exec_1 = require("./exec");
 class HaxeCompiler {
     constructor(from, temp, to, haxeDirectory, hxml, sourceDirectories) {
         this.ready = true;

--- a/out/HaxeProject.js
+++ b/out/HaxeProject.js
@@ -1,7 +1,8 @@
 "use strict";
-const fs = require('fs-extra');
-const path = require('path');
-const XmlWriter_1 = require('./XmlWriter');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const path = require("path");
+const XmlWriter_1 = require("./XmlWriter");
 function copyAndReplace(from, to, names, values) {
     let data = fs.readFileSync(from, { encoding: 'utf8' });
     for (let i = 0; i < names.length; ++i) {

--- a/out/ImageTool.js
+++ b/out/ImageTool.js
@@ -2,16 +2,17 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const child_process = require('child_process');
-const fs = require('fs-extra');
-const path = require('path');
-const log = require('./log');
-const exec_1 = require('./exec');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs-extra");
+const path = require("path");
+const log = require("./log");
+const exec_1 = require("./exec");
 function getWidthAndHeight(kha, from, to, options, format, prealpha) {
     return new Promise((resolve, reject) => {
         const exe = 'kraffiti' + exec_1.sys();

--- a/out/Options.js
+++ b/out/Options.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /*
 export var Options = {
     precompiledHeaders: false,

--- a/out/Platform.js
+++ b/out/Platform.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.Platform = {
     Krom: 'krom',
     Windows: 'windows',

--- a/out/Project.js
+++ b/out/Project.js
@@ -1,8 +1,9 @@
 "use strict";
-const child_process = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const log = require('./log');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const log = require("./log");
 class Library {
 }
 exports.Library = Library;
@@ -93,8 +94,7 @@ class Project {
         let self = this;
         function findLibraryDirectory(name) {
             if (path.isAbsolute(name)) {
-                const dirs = name.split('/');
-                return { libpath: name, libroot: dirs[dirs.length - 1] };
+                return { libpath: name, libroot: name };
             }
             // Tries to load the default library from inside the kha project.
             // e.g. 'Libraries/wyngine'

--- a/out/ProjectFile.js
+++ b/out/ProjectFile.js
@@ -2,15 +2,16 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const fs = require('fs');
-const path = require('path');
-const Platform_1 = require('./Platform');
-const Project_1 = require('./Project');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const path = require("path");
+const Platform_1 = require("./Platform");
+const Project_1 = require("./Project");
 function loadProject(from, projectfile, platform) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise((resolve, reject) => {

--- a/out/ShaderCompiler.js
+++ b/out/ShaderCompiler.js
@@ -2,20 +2,21 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const child_process = require('child_process');
-const fs = require('fs-extra');
-const os = require('os');
-const path = require('path');
-const chokidar = require('chokidar');
-const GraphicsApi_1 = require('./GraphicsApi');
-const Platform_1 = require('./Platform');
-const AssetConverter_1 = require('./AssetConverter');
-const log = require('./log');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs-extra");
+const os = require("os");
+const path = require("path");
+const chokidar = require("chokidar");
+const GraphicsApi_1 = require("./GraphicsApi");
+const Platform_1 = require("./Platform");
+const AssetConverter_1 = require("./AssetConverter");
+const log = require("./log");
 class CompiledShader {
     constructor() {
         this.files = [];

--- a/out/VisualStudioVersion.js
+++ b/out/VisualStudioVersion.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.VisualStudioVersion = {
     VS2010: 'vs2010',
     VS2012: 'vs2012',

--- a/out/VrApi.js
+++ b/out/VrApi.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.VrApi = {
     GearVr: 'gearvr',
     Cardboard: 'cardboard',

--- a/out/XmlWriter.js
+++ b/out/XmlWriter.js
@@ -1,5 +1,6 @@
 "use strict";
-const fs = require('fs-extra');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
 function printElement(elem, data, indents) {
     for (let i = 0; i < indents; ++i)
         data += '\t';

--- a/out/exec.js
+++ b/out/exec.js
@@ -1,5 +1,6 @@
 "use strict";
-const os = require('os');
+Object.defineProperty(exports, "__esModule", { value: true });
+const os = require("os");
 function sys() {
     if (os.platform() === 'linux') {
         if (os.arch() === 'arm')

--- a/out/init.js
+++ b/out/init.js
@@ -1,6 +1,7 @@
 "use strict";
-const fs = require('fs');
-const path = require('path');
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const path = require("path");
 function run(name, from, projectfile) {
     if (!fs.existsSync(path.join(from, projectfile))) {
         fs.writeFileSync(path.join(from, projectfile), 'let project = new Project(\'New Project\');\n'

--- a/out/khamake.js
+++ b/out/khamake.js
@@ -5,18 +5,19 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const os = require('os');
-const path = require('path');
-const GraphicsApi_1 = require('./GraphicsApi');
-const VrApi_1 = require('./VrApi');
-const Options_1 = require('./Options');
-const Platform_1 = require('./Platform');
-const VisualStudioVersion_1 = require('./VisualStudioVersion');
+Object.defineProperty(exports, "__esModule", { value: true });
+const os = require("os");
+const path = require("path");
+const GraphicsApi_1 = require("./GraphicsApi");
+const VrApi_1 = require("./VrApi");
+const Options_1 = require("./Options");
+const Platform_1 = require("./Platform");
+const VisualStudioVersion_1 = require("./VisualStudioVersion");
 let version = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
 if (version < 6) {
     console.error('Requires Node.js version 6 or higher.');

--- a/out/korepath.js
+++ b/out/korepath.js
@@ -1,5 +1,6 @@
 "use strict";
-const path = require('path');
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
 let korepath = path.join(__dirname, '..', '..', '..', 'Kore', 'Tools', 'koremake');
 function init(options) {
     korepath = path.join(options.kha, 'Kore', 'Tools', 'koremake');

--- a/out/log.js
+++ b/out/log.js
@@ -1,4 +1,5 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 let myInfo = function (text) {
     console.log(text);
 };

--- a/out/main.js
+++ b/out/main.js
@@ -2,38 +2,39 @@
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
         function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const child_process = require('child_process');
-const fs = require('fs-extra');
-const path = require('path');
-const exec_1 = require('./exec');
-const korepath = require('./korepath');
-const log = require('./log');
-const Platform_1 = require('./Platform');
-const ProjectFile_1 = require('./ProjectFile');
-const AssetConverter_1 = require('./AssetConverter');
-const HaxeCompiler_1 = require('./HaxeCompiler');
-const ShaderCompiler_1 = require('./ShaderCompiler');
-const AndroidExporter_1 = require('./Exporters/AndroidExporter');
-const DebugHtml5Exporter_1 = require('./Exporters/DebugHtml5Exporter');
-const EmptyExporter_1 = require('./Exporters/EmptyExporter');
-const FlashExporter_1 = require('./Exporters/FlashExporter');
-const Html5Exporter_1 = require('./Exporters/Html5Exporter');
-const Html5WorkerExporter_1 = require('./Exporters/Html5WorkerExporter');
-const JavaExporter_1 = require('./Exporters/JavaExporter');
-const KoreExporter_1 = require('./Exporters/KoreExporter');
-const KoreHLExporter_1 = require('./Exporters/KoreHLExporter');
-const KromExporter_1 = require('./Exporters/KromExporter');
-const NodeExporter_1 = require('./Exporters/NodeExporter');
-const PlayStationMobileExporter_1 = require('./Exporters/PlayStationMobileExporter');
-const WpfExporter_1 = require('./Exporters/WpfExporter');
-const XnaExporter_1 = require('./Exporters/XnaExporter');
-const UnityExporter_1 = require('./Exporters/UnityExporter');
-const HaxeProject_1 = require('./HaxeProject');
+Object.defineProperty(exports, "__esModule", { value: true });
+const child_process = require("child_process");
+const fs = require("fs-extra");
+const path = require("path");
+const exec_1 = require("./exec");
+const korepath = require("./korepath");
+const log = require("./log");
+const Platform_1 = require("./Platform");
+const ProjectFile_1 = require("./ProjectFile");
+const AssetConverter_1 = require("./AssetConverter");
+const HaxeCompiler_1 = require("./HaxeCompiler");
+const ShaderCompiler_1 = require("./ShaderCompiler");
+const AndroidExporter_1 = require("./Exporters/AndroidExporter");
+const DebugHtml5Exporter_1 = require("./Exporters/DebugHtml5Exporter");
+const EmptyExporter_1 = require("./Exporters/EmptyExporter");
+const FlashExporter_1 = require("./Exporters/FlashExporter");
+const Html5Exporter_1 = require("./Exporters/Html5Exporter");
+const Html5WorkerExporter_1 = require("./Exporters/Html5WorkerExporter");
+const JavaExporter_1 = require("./Exporters/JavaExporter");
+const KoreExporter_1 = require("./Exporters/KoreExporter");
+const KoreHLExporter_1 = require("./Exporters/KoreHLExporter");
+const KromExporter_1 = require("./Exporters/KromExporter");
+const NodeExporter_1 = require("./Exporters/NodeExporter");
+const PlayStationMobileExporter_1 = require("./Exporters/PlayStationMobileExporter");
+const WpfExporter_1 = require("./Exporters/WpfExporter");
+const XnaExporter_1 = require("./Exporters/XnaExporter");
+const UnityExporter_1 = require("./Exporters/UnityExporter");
+const HaxeProject_1 = require("./HaxeProject");
 let lastAssetConverter;
 let lastShaderCompiler;
 let lastHaxeCompiler;

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -125,8 +125,7 @@ export class Project {
 		let self = this;
 		function findLibraryDirectory(name: string) {
 			if (path.isAbsolute(name)) {
-				const dirs = name.split('/');
-				return { libpath: name, libroot: dirs[dirs.length - 1] };
+				return { libpath: name, libroot: name };
 			}
 			// Tries to load the default library from inside the kha project.
 			// e.g. 'Libraries/wyngine'


### PR DESCRIPTION
This change fixes using
```
project.addFile();
project.addIncludeDir();
...
```

commands in korefiles of libraries referenced with absolute path.

Compiled with tsc 2.2.1.