### PR TITLE
Honor graphics option for Krom

### DIFF
--- a/out/ShaderCompiler.js
+++ b/out/ShaderCompiler.js
@@ -110,8 +110,17 @@ class ShaderCompiler {
             case Platform_1.Platform.Unity:
                 return 'hlsl';
             case Platform_1.Platform.Krom:
-                if (os.platform() === 'win32') {
+                if (options.graphics === GraphicsApi_1.GraphicsApi.Direct3D11 || options.graphics === GraphicsApi_1.GraphicsApi.Direct3D12) {
                     return 'd3d11';
+                }
+                else if (options.graphics === GraphicsApi_1.GraphicsApi.Direct3D9) {
+                    return 'd3d9';
+                }
+                else if (options.graphics === GraphicsApi_1.GraphicsApi.Vulkan) {
+                    return 'spirv';
+                }
+                else if (options.graphics === GraphicsApi_1.GraphicsApi.Metal) {
+                    return 'metal';
                 }
                 else {
                     return 'glsl';

--- a/out/khamake.js
+++ b/out/khamake.js
@@ -1,7 +1,7 @@
-"use strict";
 // Called from entry point, e.g. Kha/make.js
 // This is where options are processed:
 // e.g. '-t html5 --server'
+"use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -24,14 +24,18 @@ if (version < 6) {
     process.exit(1);
 }
 let defaultTarget;
+let defaultGraphics;
 if (os.platform() === 'linux') {
     defaultTarget = Platform_1.Platform.Linux;
+    defaultGraphics = GraphicsApi_1.GraphicsApi.OpenGL;
 }
 else if (os.platform() === 'win32') {
     defaultTarget = Platform_1.Platform.Windows;
+    defaultGraphics = GraphicsApi_1.GraphicsApi.Direct3D11;
 }
 else {
     defaultTarget = Platform_1.Platform.OSX;
+    defaultGraphics = GraphicsApi_1.GraphicsApi.OpenGL;
 }
 let options = [
     {
@@ -77,7 +81,7 @@ let options = [
         short: 'g',
         description: 'Graphics api to use. Possible parameters are direct3d9, direct3d11, direct3d12, metal and opengl.',
         value: true,
-        default: GraphicsApi_1.GraphicsApi.Direct3D11
+        default: defaultGraphics
     },
     {
         full: 'visualstudio',

--- a/src/ShaderCompiler.ts
+++ b/src/ShaderCompiler.ts
@@ -125,8 +125,17 @@ export class ShaderCompiler {
 		case Platform.Unity:
 			return 'hlsl';
 		case Platform.Krom:
-			if (os.platform() === 'win32') {
+			if (options.graphics === GraphicsApi.Direct3D11 || options.graphics === GraphicsApi.Direct3D12) {
 				return 'd3d11';
+			}
+			else if (options.graphics === GraphicsApi.Direct3D9) {
+				return 'd3d9';
+			}
+			else if (options.graphics === GraphicsApi.Vulkan) {
+				return 'spirv';
+			}
+			else if (options.graphics === GraphicsApi.Metal) {
+				return 'metal';
 			}
 			else {
 				return 'glsl';

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -20,14 +20,18 @@ if (version < 6) {
 }
 
 let defaultTarget: string;
+let defaultGraphics: string;
 if (os.platform() === 'linux') {
 	defaultTarget = Platform.Linux;
+	defaultGraphics = GraphicsApi.OpenGL;
 }
 else if (os.platform() === 'win32') {
 	defaultTarget = Platform.Windows;
+	defaultGraphics = GraphicsApi.Direct3D11;
 }
 else {
 	defaultTarget = Platform.OSX;
+	defaultGraphics = GraphicsApi.OpenGL;
 }
 
 let options: Array<any> = [
@@ -74,7 +78,7 @@ let options: Array<any> = [
 		short: 'g',
 		description: 'Graphics api to use. Possible parameters are direct3d9, direct3d11, direct3d12, metal and opengl.',
 		value: true,
-		default: GraphicsApi.Direct3D11
+		default: defaultGraphics
 	},
 	{
 		full: 'visualstudio',


### PR DESCRIPTION
Default behaviour should be unchanged. Using this one can package Krom app for different OS, or build Krom binaries for multiple graphic apis. 