### PR TITLE
Audio asset compression for AndroidExporter

### DIFF
--- a/out/Exporters/AndroidExporter.js
+++ b/out/Exporters/AndroidExporter.js
@@ -12,6 +12,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const KhaExporter_1 = require("./KhaExporter");
 const ImageTool_1 = require("../ImageTool");
+const Converter_1 = require("../Converter");
 function findIcon(from, options) {
     if (fs.existsSync(path.join(from, 'icon.png')))
         return path.join(from, 'icon.png');
@@ -131,10 +132,17 @@ class AndroidExporter extends KhaExporter_1.KhaExporter {
             callback([to + '.ogg']);
         });
     }*/
-    copySound(platform, from, to) {
+    copySound(platform, from, to, options) {
         return __awaiter(this, void 0, void 0, function* () {
-            fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.wav'), { clobber: true });
-            return [to + '.wav'];
+            if (options.quality < 1) {
+                fs.ensureDirSync(path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', path.dirname(to)));
+                let ogg = yield Converter_1.convert(from, path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.ogg'), this.options.ogg);
+                return [to + '.ogg'];
+            }
+            else {
+                fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.wav'), { clobber: true });
+                return [to + '.wav'];
+            }
         });
     }
     copyImage(platform, from, to, asset, cache) {

--- a/src/Exporters/AndroidExporter.ts
+++ b/src/Exporters/AndroidExporter.ts
@@ -143,9 +143,16 @@ export class AndroidExporter extends KhaExporter {
 		});
 	}*/
 
-	async copySound(platform: string, from: string, to: string) {
-		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.wav'), { clobber: true });
-		return [to + '.wav'];
+	async copySound(platform: string, from: string, to: string, options: any) {
+		if (options.quality < 1) {
+			fs.ensureDirSync(path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', path.dirname(to)));
+			let ogg = await convert(from, path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.ogg'), this.options.ogg);
+			return [to + '.ogg'];
+		}
+		else {
+			fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.wav'), { clobber: true });
+			return [to + '.wav'];
+		}
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {


### PR DESCRIPTION
Compress audio assets to ogg vorbis if quality option is smaller than 1.
Works with audio implementation in [this pull request](https://github.com/Kode/Kha/pull/637).