### PR TITLE
remove leading slash for root directory assets

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -33,7 +33,10 @@ class AssetConverter {
         if (options.namePathSeparator) {
             dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
         }
-        return pattern.replace(/{name}/g, value).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+        const dirRegex = dirValue === ''
+            ? /{dir}\//g
+            : /{dir}/g;
+        return pattern.replace(/{name}/g, value).replace(/{ext}/g, fileinfo.ext).replace(dirRegex, dirValue);
     }
     static createExportInfo(fileinfo, keepextension, options, from) {
         let nameValue = fileinfo.name;

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -31,7 +31,12 @@ export class AssetConverter {
 		if (options.namePathSeparator) {
 			dirValue = dirValue.split(path.sep).join(options.namePathSeparator);
 		}
-		return pattern.replace(/{name}/g, value).replace(/{ext}/g, fileinfo.ext).replace(/{dir}/g, dirValue);
+
+		const dirRegex = dirValue === ''
+			? /{dir}\//g
+			: /{dir}/g;
+
+		return pattern.replace(/{name}/g, value).replace(/{ext}/g, fileinfo.ext).replace(dirRegex, dirValue);
 	}
 	
 	static createExportInfo(fileinfo: path.ParsedPath, keepextension: boolean, options: any, from: string): {name: string, destination: string} {


### PR DESCRIPTION
When using ```project.addAssets('assets/**', { nameBaseDir: "assets", destination: '{dir}/{name}', name: '{dir}/{name}' });``` assets in the basepath will end up as f.ex. ```/arial.ttf``` in files.json. This will crash the actual asset loading and they will appear with a superfluous underscore (Assets.fonts._arial).

This PR fixes both issues.
