### PR TITLE
return an error exitcode that can be handled on the commandline

### DIFF
--- a/out/khamake.js
+++ b/out/khamake.js
@@ -298,6 +298,7 @@ function runKhamake() {
         }
         catch (error) {
             console.log(error);
+            process.exit(1);
         }
     });
 }

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -298,6 +298,7 @@ async function runKhamake() {
 	}
 	catch (error) {
 		console.log(error);
+		process.exit(1);
 	}
 }
 


### PR DESCRIPTION
With this PR, khamake now doesn't always just return 0, but 1 in case of errors.
