### PR TITLE
show khafile.js in KodeStudio

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -199,7 +199,13 @@ function exportKhaProject(options) {
         // then create the project config object, which contains stuff
         // like project name, assets paths, sources path, library path...
         if (fs.existsSync(path.join(options.from, options.projectfile))) {
-            projectData = yield ProjectFile_1.loadProject(options.from, options.projectfile, options.target);
+            try {
+                projectData = yield ProjectFile_1.loadProject(options.from, options.projectfile, options.target);
+            }
+            catch (x) {
+                log.error(x);
+                throw 'Loading the projectfile failed.';
+            }
             project = projectData.project;
             foundProjectFile = true;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,7 +215,13 @@ async function exportKhaProject(options: Options): Promise<string> {
 	// then create the project config object, which contains stuff
 	// like project name, assets paths, sources path, library path...
 	if (fs.existsSync(path.join(options.from, options.projectfile))) {
-		projectData = await loadProject(options.from, options.projectfile, options.target);
+		try {
+			projectData = await loadProject(options.from, options.projectfile, options.target);
+		} catch (x) {
+			log.error(x);
+			throw 'Loading the projectfile failed.';
+		}
+		
 		project = projectData.project;
 		foundProjectFile = true;
 	}


### PR DESCRIPTION
Errors in khafile.js are shown during the build process now. For running (F5) it even opens an
```[Error] Compilation failed``` popup.
