### PR TITLE
bring back the --ogg option

### DIFF
--- a/out/khamake.js
+++ b/out/khamake.js
@@ -121,6 +121,12 @@ let options = [
         default: ''
     },
     {
+        full: 'ogg',
+        description: 'Commandline for running the ogg encoder',
+        value: true,
+        default: ''
+    },
+    {
         full: 'krafix',
         description: 'Location of krafix shader compiler',
         value: true,

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -118,6 +118,12 @@ let options: Array<any> = [
 		default: ''
 	},
 	{
+		full: 'ogg',
+		description: 'Commandline for running the ogg encoder',
+		value: true,
+		default: ''
+	},
+	{
 		full: 'krafix',
 		description: 'Location of krafix shader compiler',
 		value: true,


### PR DESCRIPTION
It is mentioned in Options.ts, but wasn't mapped khamake.ts. Now it's usable again like:

```shell
node Kha/make --target html5 --ogg "Kha/Tools/oggenc/oggenc {in} -o {out} -s 42"
```

The actual problem i was facing is that oggenc generated files are never binary identical, because they're encoded with some random seed in case you encode multiple files at ones. Using a fixed seed (```-s 42``` like in the example above) fixes that.
