### PR TITLE
Watch for change only in --watch mode

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -71,17 +71,19 @@ class AssetConverter {
                     files.push(file);
                 }
             });
-            this.watcher.on('change', (file) => {
-                if (ready) {
-                    let fileinfo = path.parse(file);
-                    switch (fileinfo.ext) {
-                        case '.png':
-                            log.info('Reexporting ' + fileinfo.name);
-                            this.exporter.copyImage(this.platform, file, fileinfo.name, {}, {});
-                            break;
+            if (watch) {
+                this.watcher.on('change', (file) => {
+                    if (ready) {
+                        let fileinfo = path.parse(file);
+                        switch (fileinfo.ext) {
+                            case '.png':
+                                log.info('Reexporting ' + fileinfo.name);
+                                this.exporter.copyImage(this.platform, file, fileinfo.name, {}, {});
+                                break;
+                        }
                     }
-                }
-            });
+                });
+            }
             this.watcher.on('ready', async () => {
                 ready = true;
                 let parsedFiles = [];

--- a/out/ShaderCompiler.js
+++ b/out/ShaderCompiler.js
@@ -174,17 +174,19 @@ class ShaderCompiler {
                     }
                 }
             });
-            this.watcher.on('change', (filepath) => {
-                let file = path.parse(filepath);
-                switch (file.ext) {
-                    case '.glsl':
-                        if (!file.name.endsWith('.inc')) {
-                            log.info('Recompiling ' + file.name);
-                            this.compileShader(filepath, options, recompileAll);
-                        }
-                        break;
-                }
-            });
+            if (watch) {
+                this.watcher.on('change', (filepath) => {
+                    let file = path.parse(filepath);
+                    switch (file.ext) {
+                        case '.glsl':
+                            if (!file.name.endsWith('.inc')) {
+                                log.info('Recompiling ' + file.name);
+                                this.compileShader(filepath, options, recompileAll);
+                            }
+                            break;
+                    }
+                });
+            }
             this.watcher.on('unlink', (file) => {
             });
             this.watcher.on('ready', async () => {

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -87,19 +87,19 @@ export class AssetConverter {
 					files.push(file);
 				}
 			});
-			
-			this.watcher.on('change', (file: string) => {
-				if (ready) {
-					let fileinfo = path.parse(file);
-					switch (fileinfo.ext) {
-						case '.png':
-							log.info('Reexporting ' + fileinfo.name);
-							this.exporter.copyImage(this.platform, file, fileinfo.name, {}, {});
-							break;
+			if (watch) {
+				this.watcher.on('change', (file: string) => {
+					if (ready) {
+						let fileinfo = path.parse(file);
+						switch (fileinfo.ext) {
+							case '.png':
+								log.info('Reexporting ' + fileinfo.name);
+								this.exporter.copyImage(this.platform, file, fileinfo.name, {}, {});
+								break;
+						}
 					}
-				}
-			});
-			
+				});
+			}
 			this.watcher.on('ready', async () => {
 				ready = true;
 				let parsedFiles: { name: string, from: string, type: string, files: string[], original_width: number, original_height: number, readable: boolean }[] = [];

--- a/src/ShaderCompiler.ts
+++ b/src/ShaderCompiler.ts
@@ -198,17 +198,19 @@ export class ShaderCompiler {
 					}
 				}
 			});
-			this.watcher.on('change', (filepath: string) => {
-				let file = path.parse(filepath);
-				switch (file.ext) {
-					case '.glsl':
-						if (!file.name.endsWith('.inc')) {
-							log.info('Recompiling ' + file.name);
-							this.compileShader(filepath, options, recompileAll);
-						}
-						break;
-				}
-			});
+			if (watch) {
+				this.watcher.on('change', (filepath: string) => {
+					let file = path.parse(filepath);
+					switch (file.ext) {
+						case '.glsl':
+							if (!file.name.endsWith('.inc')) {
+								log.info('Recompiling ' + file.name);
+								this.compileShader(filepath, options, recompileAll);
+							}
+							break;
+					}
+				});
+			}
 			this.watcher.on('unlink', (file: string) => {
 
 			});


### PR DESCRIPTION
Started to get random `Recompiling` / `Reexporting` messages when calling khamake, which in some cases corrupts the files or halts with `Error: ENOENT: no such file or directory`. I am not sure if this is Windows Defender randomly touching files or what.

This PR listens to `'change'` only in `--watch` mode.

Fixes https://github.com/Kode/khamake/issues/102, I also get this running `node Kha/make` like usual.