### PR TITLE
Use absolute path instead of relative for local libraries.

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -147,7 +147,7 @@ export class Project {
 			// e.g. 'Libraries/wyngine'
 			let libpath = path.join(self.scriptdir, self.localLibraryPath, name);
 			if (fs.existsSync(libpath) && fs.statSync(libpath).isDirectory()) {
-				return { libpath: libpath, libroot: self.localLibraryPath + '/' + name };
+				return { libpath: process.cwd() + '/' + libpath, libroot: self.localLibraryPath + '/' + name };
 			}
 			// If the library couldn't be found in Libraries folder, try
 			// looking in the haxelib folders.

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -147,7 +147,7 @@ export class Project {
 			// e.g. 'Libraries/wyngine'
 			let libpath = path.join(self.scriptdir, self.localLibraryPath, name);
 			if (fs.existsSync(libpath) && fs.statSync(libpath).isDirectory()) {
-				return { libpath: process.cwd() + '/' + libpath, libroot: self.localLibraryPath + '/' + name };
+				return { libpath: path.resolve(libpath), libroot: self.localLibraryPath + '/' + name };
 			}
 			// If the library couldn't be found in Libraries folder, try
 			// looking in the haxelib folders.


### PR DESCRIPTION
Because VSCode autocomplete can't parse things like ..\Libraries\my_lib in hxml files.