### PR TITLE
Fix --watch mode terminating on errors

### DIFF
--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -31,7 +31,6 @@ class HaxeCompiler {
     }
     async run(watch) {
         if (watch) {
-            await this.compile();
             this.watcher = chokidar.watch(this.sourceMatchers, { ignored: /[\/\\]\.git/, persistent: true, ignoreInitial: true });
             this.watcher.on('add', (file) => {
                 this.scheduleCompile();
@@ -43,6 +42,7 @@ class HaxeCompiler {
                 this.scheduleCompile();
             });
             this.startCompilationServer();
+            this.triggerCompilationServer();
         }
         else {
             try {
@@ -131,15 +131,21 @@ class HaxeCompiler {
         this.todo = false;
         return new Promise((resolve, reject) => {
             this.runHaxe(['--connect', this.port, this.hxml], (code) => {
-                if (this.to) {
+                if (this.to && fs.existsSync(path.join(this.from, this.temp))) {
                     fs.renameSync(path.join(this.from, this.temp), path.join(this.from, this.to));
                 }
                 this.ready = true;
-                log.info('Haxe compile end.');
+                if (code === 0) {
+                    log.info('Haxe compile end.');
+                }
+                else {
+                    log.info('Haxe compile error.');
+                }
                 if (code === 0)
                     resolve();
-                else
-                    reject('Haxe compiler error.');
+                // (node:3630) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future,
+                // promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
+                //else reject('Haxe compiler error.');
                 if (this.todo) {
                     this.scheduleCompile();
                 }
@@ -150,7 +156,7 @@ class HaxeCompiler {
         return new Promise((resolve, reject) => {
             this.runHaxe([this.hxml], (code) => {
                 if (code === 0) {
-                    if (this.to) {
+                    if (this.to && fs.existsSync(path.join(this.from, this.temp))) {
                         fs.renameSync(path.join(this.from, this.temp), path.join(this.from, this.to));
                     }
                     resolve();


### PR DESCRIPTION
This fixes a three issues with `--watch` mode (see below). In short, with this PR, you can just start make in `--watch` mode and rely on all changes being compiled until you terminate the make process.

Issues fixed:

* in master, when one compilation yields an error, the watch mode is no longer functional thereafter
* if the initial compilation after starting fails, the process will keep running, but will not watch
* sometimes a compilation code of 0 is returned, even though an error occured and the temp file does not exist; in these cases, currently, the process terminates:

```
fs.js:766
  return binding.rename(pathModule._makeLong(oldPath),
                 ^

Error: ENOENT: no such file or directory, rename 'build/krom/krom.js.temp' -> 'build/krom/krom.js'
    at Object.fs.renameSync (fs.js:766:18)
    at runHaxe (/Kode Studio.app/Contents/Resources/app/extensions/kha/Kha/Tools/khamake/out/HaxeCompiler.js:143:24)
    at ChildProcess.haxe.runHaxeAgain (//Kode Studio.app/Contents/Resources/app/extensions/kha/Kha/Tools/khamake/out/HaxeCompiler.js:128:13)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
```

Also, I disabled the promise rejection in `triggerCompilation`, as node.js issues the following error:

```
(node:3630) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:3630) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

**EDIT** Should fix https://github.com/Kode/Krom/issues/26.