### PR TITLE
Parallel shader compilation

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -177,7 +177,6 @@ class AssetConverter {
                     }
                 }
                 if (this.options.parallelAssetConversion !== 0) {
-                    log.info('[WARNING] Parallel asset conversion is experimental!');
                     let todo = files.map((file, index) => {
                         return async () => {
                             await convertAsset(file, index);

--- a/out/ShaderCompiler.js
+++ b/out/ShaderCompiler.js
@@ -196,7 +196,7 @@ class ShaderCompiler {
             this.watcher.on('ready', async () => {
                 ready = true;
                 let compiledShaders = [];
-                var self = this;
+                const self = this;
                 async function compile(shader, index) {
                     let parsed = path.parse(shader);
                     log.info('Compiling shader ' + (index + 1) + ' of ' + shaders.length + ' (' + parsed.base + ').');

--- a/out/khamake.js
+++ b/out/khamake.js
@@ -223,7 +223,7 @@ let options = [
     },
     {
         full: 'parallelAssetConversion',
-        description: 'Spawn multiple processes during asset conversion. Possible values:\n  0: disabled (default value)\n -1: choose number of processes automatically\n  N: specify number of processes manually',
+        description: 'Experimental - Spawn multiple processes during asset and shader conversion. Possible values:\n  0: disabled (default value)\n -1: choose number of processes automatically\n  N: specify number of processes manually',
         value: true,
         default: 0
     }

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -198,8 +198,6 @@ export class AssetConverter {
 				}
 
 				if (this.options.parallelAssetConversion !== 0) {
-					log.info('[WARNING] Parallel asset conversion is experimental!');
-
 					let todo = files.map((file, index) => {
 						return async () => {
 							await convertAsset(file, index);

--- a/src/ShaderCompiler.ts
+++ b/src/ShaderCompiler.ts
@@ -222,7 +222,7 @@ export class ShaderCompiler {
 				ready = true;
 				let compiledShaders: CompiledShader[] = [];
 				
-				var self = this;
+				const self = this;
  				async function compile( shader: any, index: number ) {
 					let parsed = path.parse(shader);
 					log.info('Compiling shader ' + (index + 1) + ' of ' + shaders.length + ' (' + parsed.base + ').');
@@ -256,7 +256,7 @@ export class ShaderCompiler {
 					let todo = shaders.map((shader, index) => {
 						return async () => {
 							await compile(shader, index);
-						}
+						};
 					});
 
 					let processes = this.options.parallelAssetConversion === -1

--- a/src/ShaderCompiler.ts
+++ b/src/ShaderCompiler.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as chokidar from 'chokidar';
+import * as Throttle from 'promise-parallel-throttle';
 import {KhaExporter} from './Exporters/KhaExporter';
 import {GraphicsApi} from './GraphicsApi';
 import {Options} from './Options';
@@ -220,13 +221,14 @@ export class ShaderCompiler {
 			this.watcher.on('ready', async () => {
 				ready = true;
 				let compiledShaders: CompiledShader[] = [];
-				let index = 0;
-				for (let shader of shaders) {
+				
+				var self = this;
+ 				async function compile( shader: any, index: number ) {
 					let parsed = path.parse(shader);
 					log.info('Compiling shader ' + (index + 1) + ' of ' + shaders.length + ' (' + parsed.base + ').');
 					let compiledShader: CompiledShader = null;
 					try {
-						compiledShader = await this.compileShader(shader, options, recompileAll);
+						compiledShader = await self.compileShader(shader, options, recompileAll);
 					}
 					catch (error) {
 						log.error('Compiling shader ' + (index + 1) + ' of ' + shaders.length + ' (' + parsed.base + ') failed:');
@@ -243,12 +245,36 @@ export class ShaderCompiler {
 					}
 					if (compiledShader.files != null && compiledShader.files.length === 0) {
 						// TODO: Remove when krafix has been recompiled everywhere
-						compiledShader.files.push(parsed.name + '.' + this.type);
+						compiledShader.files.push(parsed.name + '.' + self.type);
 					}
-					compiledShader.name = AssetConverter.createExportInfo(parsed, false, options, this.exporter.options.from).name;
+					compiledShader.name = AssetConverter.createExportInfo(parsed, false, options, self.exporter.options.from).name;
 					compiledShaders.push(compiledShader);
 					++index;
 				}
+
+				if (this.options.parallelAssetConversion !== 0) {
+					let todo = shaders.map((shader, index) => {
+						return async () => {
+							await compile(shader, index);
+						}
+					});
+
+					let processes = this.options.parallelAssetConversion === -1
+						? require('os').cpus().length - 1
+						: this.options.parallelAssetConversion;
+
+					await Throttle.all(todo, {
+						maxInProgress: processes,
+					});
+				}
+				else {
+					let index = 0;
+					for (let shader of shaders) {
+						await compile(shader, index);
+						index += 1;
+					}
+				}
+
 				resolve(compiledShaders);
 				return;
 			});

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -224,7 +224,7 @@ let options: Array<any> = [
 	},
 	{
 		full: 'parallelAssetConversion',
-		description: 'Spawn multiple processes during asset conversion. Possible values:\n  0: disabled (default value)\n -1: choose number of processes automatically\n  N: specify number of processes manually',
+		description: 'Experimental - Spawn multiple processes during asset and shader conversion. Possible values:\n  0: disabled (default value)\n -1: choose number of processes automatically\n  N: specify number of processes manually',
 		value: true,
 		default: 0
 	}


### PR DESCRIPTION
Applied https://github.com/Kode/khamake/pull/152 by @sh-dave to ShaderCompiler. Compiling 60 shaders went from 4.2sec down to 2.2sec (on a poor i3 CPU). Hooray!
I moved the experimental notice to parameter description to be a little quieter.

Fixes https://github.com/Kode/khamake/issues/127.