### PR TITLE
Add kha_project_name define

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -97,6 +97,7 @@ async function exportProjectFiles(name, resourceDir, options, exporter, kore, ko
         let haxeOptions = exporter.haxeOptions(name, targetOptions, defines);
         haxeOptions.defines.push('kha');
         haxeOptions.defines.push('kha_version=1810');
+        haxeOptions.defines.push('kha_project_name=' + haxeOptions.name);
         haxeOptions.safeName = safeName(haxeOptions.name);
         if (options.debug && haxeOptions.parameters.indexOf('-debug') < 0) {
             haxeOptions.parameters.push('-debug');

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,6 +110,7 @@ async function exportProjectFiles(name: string, resourceDir: string, options: Op
 		let haxeOptions = exporter.haxeOptions(name, targetOptions, defines);
 		haxeOptions.defines.push('kha');
 		haxeOptions.defines.push('kha_version=1810');
+		haxeOptions.defines.push('kha_project_name=' + haxeOptions.name);
 		haxeOptions.safeName = safeName(haxeOptions.name);
 
 		if (options.debug && haxeOptions.parameters.indexOf('-debug') < 0) {


### PR DESCRIPTION
In this case we can set project name only in `khafile.js`, without `title` in `System.start({...})`.