### PR TITLE
Honor debug flag in Krom exporter

### DIFF
--- a/out/Exporters/KromExporter.js
+++ b/out/Exporters/KromExporter.js
@@ -13,7 +13,6 @@ class KromExporter extends KhaExporter_1.KhaExporter {
         return 'Krom';
     }
     haxeOptions(name, targetOptions, defines) {
-        defines.push('js-classic');
         defines.push('sys_' + this.options.target);
         defines.push('sys_g1');
         defines.push('sys_g2');
@@ -31,7 +30,10 @@ class KromExporter extends KhaExporter_1.KhaExporter {
         defines.push('kha_g4');
         defines.push('kha_a1');
         defines.push('kha_a2');
-        this.parameters.push('-debug');
+        if (this.options.debug) {
+            this.parameters.push('-debug');
+            defines.push('js-classic');
+        }
         return {
             from: this.options.from.toString(),
             to: path.join(this.sysdir(), 'krom.js.temp'),

--- a/out/khamake.js
+++ b/out/khamake.js
@@ -196,7 +196,7 @@ let options = [
     },
     {
         full: 'debug',
-        description: 'Compile in debug mode for native targets.',
+        description: 'Compile in debug mode.',
         value: false
     },
     {

--- a/src/Exporters/KromExporter.ts
+++ b/src/Exporters/KromExporter.ts
@@ -20,8 +20,6 @@ export class KromExporter extends KhaExporter {
 	}
 
 	haxeOptions(name: string, targetOptions: any, defines: Array<string>) {
-		defines.push('js-classic');
-
 		defines.push('sys_' + this.options.target);
 		defines.push('sys_g1');
 		defines.push('sys_g2');
@@ -41,7 +39,10 @@ export class KromExporter extends KhaExporter {
 		defines.push('kha_a1');
 		defines.push('kha_a2');
 
-		this.parameters.push('-debug');
+		if (this.options.debug) {
+			this.parameters.push('-debug');
+			defines.push('js-classic');
+		}
 		
 		return {
 			from: this.options.from.toString(),

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -197,7 +197,7 @@ let options: Array<any> = [
 	},
 	{
 		full: 'debug',
-		description: 'Compile in debug mode for native targets.',
+		description: 'Compile in debug mode.',
 		value: false
 	},
 	{


### PR DESCRIPTION
This lets Krom exporter omit the debug stuff unless `--debug` flag is enabled. It reduces the minified `krom.js` size and slightly improves compile times.

Tested on some armory projects:
- first-person-template.js: 784KB -> 682KB
- armor-paint.js: 956KB -> 829KB
- ~0.2sec faster compile time

If this approach looks ok then this is to go with https://github.com/Kode/vscode-kha/pull/8.