### PR TITLE
Fix graphics api define

### DIFF
--- a/out/Exporters/KoreExporter.js
+++ b/out/Exporters/KoreExporter.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs-extra");
 const path = require("path");
+const defaults = require("../defaults");
 const KhaExporter_1 = require("./KhaExporter");
 const Converter_1 = require("../Converter");
 const GraphicsApi_1 = require("../GraphicsApi");
@@ -32,7 +33,11 @@ class KoreExporter extends KhaExporter_1.KhaExporter {
         defines.push('kha_' + this.options.target);
         defines.push('kha_' + this.options.target + '_native');
         defines.push('kha_' + this.options.target + '_cpp');
-        defines.push('kha_' + this.options.graphics);
+        let graphics = this.options.graphics;
+        if (graphics === GraphicsApi_1.GraphicsApi.Default) {
+            graphics = defaults.graphicsApi(this.options.target);
+        }
+        defines.push('kha_' + graphics);
         defines.push('kha_kore');
         defines.push('kha_g1');
         defines.push('kha_g2');

--- a/out/Exporters/KoreHLExporter.js
+++ b/out/Exporters/KoreHLExporter.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs-extra");
 const path = require("path");
+const defaults = require("../defaults");
 const KhaExporter_1 = require("./KhaExporter");
 const Converter_1 = require("../Converter");
 const GraphicsApi_1 = require("../GraphicsApi");
@@ -27,7 +28,11 @@ class KoreHLExporter extends KhaExporter_1.KhaExporter {
         defines.push('kha_hl');
         defines.push('kha_' + this.options.target);
         defines.push('kha_' + this.options.target + '_hl');
-        defines.push('kha_' + this.options.graphics);
+        let graphics = this.options.graphics;
+        if (graphics === GraphicsApi_1.GraphicsApi.Default) {
+            graphics = defaults.graphicsApi(this.options.target);
+        }
+        defines.push('kha_' + graphics);
         defines.push('kha_g1');
         defines.push('kha_g2');
         defines.push('kha_g3');

--- a/out/Exporters/KromExporter.js
+++ b/out/Exporters/KromExporter.js
@@ -2,8 +2,10 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs-extra");
 const path = require("path");
+const defaults = require("../defaults");
 const KhaExporter_1 = require("./KhaExporter");
 const Converter_1 = require("../Converter");
+const GraphicsApi_1 = require("../GraphicsApi");
 const ImageTool_1 = require("../ImageTool");
 class KromExporter extends KhaExporter_1.KhaExporter {
     constructor(options) {
@@ -24,7 +26,11 @@ class KromExporter extends KhaExporter_1.KhaExporter {
         defines.push('kha_js');
         defines.push('kha_' + this.options.target);
         defines.push('kha_' + this.options.target + '_js');
-        defines.push('kha_' + this.options.graphics);
+        let graphics = this.options.graphics;
+        if (graphics === GraphicsApi_1.GraphicsApi.Default) {
+            graphics = defaults.graphicsApi(this.options.target);
+        }
+        defines.push('kha_' + graphics);
         defines.push('kha_g1');
         defines.push('kha_g2');
         defines.push('kha_g3');

--- a/out/defaults.js
+++ b/out/defaults.js
@@ -1,0 +1,38 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const GraphicsApi_1 = require("./GraphicsApi");
+const Platform_1 = require("./Platform");
+function graphicsApi(platform) {
+    switch (platform) {
+        case Platform_1.Platform.Empty:
+        case Platform_1.Platform.Node:
+        case Platform_1.Platform.Android:
+        case Platform_1.Platform.HTML5:
+        case Platform_1.Platform.DebugHTML5:
+        case Platform_1.Platform.HTML5Worker:
+        case Platform_1.Platform.Pi:
+        case Platform_1.Platform.Linux:
+            return GraphicsApi_1.GraphicsApi.OpenGL;
+        case Platform_1.Platform.tvOS:
+        case Platform_1.Platform.iOS:
+        case Platform_1.Platform.OSX:
+            return GraphicsApi_1.GraphicsApi.Metal;
+        case Platform_1.Platform.Windows:
+        case Platform_1.Platform.WindowsApp:
+            return GraphicsApi_1.GraphicsApi.Direct3D11;
+        case Platform_1.Platform.Krom:
+            if (process.platform === 'win32') {
+                return GraphicsApi_1.GraphicsApi.Direct3D11;
+            }
+            else if (process.platform === 'darwin') {
+                return GraphicsApi_1.GraphicsApi.Metal;
+            }
+            else {
+                return GraphicsApi_1.GraphicsApi.OpenGL;
+            }
+        default:
+            return platform;
+    }
+}
+exports.graphicsApi = graphicsApi;
+//# sourceMappingURL=defaults.js.map

--- a/src/Exporters/KoreExporter.ts
+++ b/src/Exporters/KoreExporter.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as defaults from '../defaults';
 import {KhaExporter} from './KhaExporter';
 import {convert} from '../Converter';
 import {executeHaxe} from '../Haxe';
@@ -38,7 +39,11 @@ export class KoreExporter extends KhaExporter {
 		defines.push('kha_' + this.options.target);
 		defines.push('kha_' + this.options.target + '_native');
 		defines.push('kha_' + this.options.target + '_cpp');
-		defines.push('kha_' + this.options.graphics);
+		let graphics = this.options.graphics;
+		if (graphics === GraphicsApi.Default) {
+			graphics = defaults.graphicsApi(this.options.target);
+		}
+		defines.push('kha_' + graphics);
 		defines.push('kha_kore');
 		defines.push('kha_g1');
 		defines.push('kha_g2');

--- a/src/Exporters/KoreHLExporter.ts
+++ b/src/Exporters/KoreHLExporter.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as defaults from '../defaults';
 import {KhaExporter} from './KhaExporter';
 import {convert} from '../Converter';
 import {executeHaxe} from '../Haxe';
@@ -33,7 +34,11 @@ export class KoreHLExporter extends KhaExporter {
 		defines.push('kha_hl');
 		defines.push('kha_' + this.options.target);
 		defines.push('kha_' + this.options.target + '_hl');
-		defines.push('kha_' + this.options.graphics);
+		let graphics = this.options.graphics;
+		if (graphics === GraphicsApi.Default) {
+			graphics = defaults.graphicsApi(this.options.target);
+		}
+		defines.push('kha_' + graphics);
 		defines.push('kha_g1');
 		defines.push('kha_g2');
 		defines.push('kha_g3');

--- a/src/Exporters/KromExporter.ts
+++ b/src/Exporters/KromExporter.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as defaults from '../defaults';
 import {KhaExporter} from './KhaExporter';
 import {convert} from '../Converter';
 import {executeHaxe} from '../Haxe';
+import {GraphicsApi} from '../GraphicsApi';
 import {Options} from '../Options';
 import {exportImage} from '../ImageTool';
 import {Library} from '../Project';
@@ -33,7 +35,11 @@ export class KromExporter extends KhaExporter {
 		defines.push('kha_js');
 		defines.push('kha_' + this.options.target);
 		defines.push('kha_' + this.options.target + '_js');
-		defines.push('kha_' + this.options.graphics);
+		let graphics = this.options.graphics;
+		if (graphics === GraphicsApi.Default) {
+			graphics = defaults.graphicsApi(this.options.target);
+		}
+		defines.push('kha_' + graphics);
 		defines.push('kha_g1');
 		defines.push('kha_g2');
 		defines.push('kha_g3');

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,35 @@
+import {GraphicsApi} from './GraphicsApi';
+import {Platform} from './Platform';
+
+export function graphicsApi(platform: string): string {
+	switch (platform) {
+	case Platform.Empty:
+	case Platform.Node:
+	case Platform.Android:
+	case Platform.HTML5:
+	case Platform.DebugHTML5:
+	case Platform.HTML5Worker:
+	case Platform.Pi:
+	case Platform.Linux:
+		return GraphicsApi.OpenGL;
+	case Platform.tvOS:
+	case Platform.iOS:
+	case Platform.OSX:
+		return GraphicsApi.Metal;
+	case Platform.Windows:
+	case Platform.WindowsApp:
+		return GraphicsApi.Direct3D11;
+	case Platform.Krom:
+		if (process.platform === 'win32') {
+			return GraphicsApi.Direct3D11;
+		}
+		else if (process.platform === 'darwin') {
+			return GraphicsApi.Metal;
+		}
+		else {
+			return GraphicsApi.OpenGL;
+		}
+	default:
+		return platform;
+	}
+}


### PR DESCRIPTION
Exports correct haxe define when graphics api is not explicitly set.

Before:
- `node Kha/make windows` -> `kha_default`
- `node Kha/make windows -g direct3d11` -> `kha_direct3d11`

After:
- `node Kha/make windows` -> `kha_direct3d11`
- `node Kha/make windows -g direct3d11` -> `kha_direct3d11`