### PR TITLE
Fix glob patterns with exclusions

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -63,7 +63,7 @@ class AssetConverter {
                 const fileinfo = path.parse(file);
                 let baseDir = path.dirname(match);
                 // fix glob patterns with exclusions
-                baseDir = baseDir.replace(/\/\*+/g, '');
+                baseDir = baseDir.replace(/\/\*+$/g, '');
                 let outPath = fileinfo.dir + path.sep + fileinfo.name;
                 outPath = path.relative(baseDir, outPath);
                 log.info('Reexporting ' + outPath + fileinfo.ext);

--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -61,7 +61,9 @@ class AssetConverter {
             this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.git/, persistent: watch });
             const onFileChange = (file) => {
                 const fileinfo = path.parse(file);
-                const baseDir = path.dirname(match);
+                let baseDir = path.dirname(match);
+                // fix glob patterns with exclusions
+                baseDir = baseDir.replace(/\/\*+/g, '');
                 let outPath = fileinfo.dir + path.sep + fileinfo.name;
                 outPath = path.relative(baseDir, outPath);
                 log.info('Reexporting ' + outPath + fileinfo.ext);

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -82,7 +82,7 @@ export class AssetConverter {
 				const fileinfo = path.parse(file);
 				let baseDir = path.dirname(match);
 				// fix glob patterns with exclusions
-				baseDir = baseDir.replace(/\/\*+/g, '');
+				baseDir = baseDir.replace(/\/\*+$/g, '');
 
 				let outPath = fileinfo.dir + path.sep + fileinfo.name;
 				outPath = path.relative(baseDir, outPath);

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -80,7 +80,10 @@ export class AssetConverter {
 
 			const onFileChange = (file: string) => {
 				const fileinfo = path.parse(file);
-				const baseDir = path.dirname(match);
+				let baseDir = path.dirname(match);
+				// fix glob patterns with exclusions
+				baseDir = baseDir.replace(/\/\*+/g, '');
+
 				let outPath = fileinfo.dir + path.sep + fileinfo.name;
 				outPath = path.relative(baseDir, outPath);
 				log.info('Reexporting ' + outPath + fileinfo.ext);


### PR DESCRIPTION
As i mention in https://github.com/Kode/khamake/pull/166#issuecomment-465637088, there is problem with patterns like `res/**/!(*.wav)`, they generates paths like `res/**` instead of `res`. This regex removes slashes with stars.