### PR TITLE
update custom targets

### DIFF
--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -73,6 +73,9 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             defines.push('sys_' + this.options.target);
             defines.push('kha_' + this.options.target);
             defines.push('kha_' + this.options.target + '_js');
+            defines.push('sys_html5');
+            defines.push('kha_html5');
+            defines.push('kha_html5_js');
         }
         if (this.isADebugTarget()) {
             this.parameters.push('-debug');

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -13,6 +13,9 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
     backend() {
         return 'HTML5';
     }
+    isADebugTarget() {
+        return this.sysdir().indexOf('debug') !== -1;
+    }
     isDebugHtml5() {
         return this.sysdir() === 'debug-html5';
     }
@@ -71,7 +74,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             defines.push('kha_' + this.options.target);
             defines.push('kha_' + this.options.target + '_js');
         }
-        if (this.isDebugHtml5()) {
+        if (this.isADebugTarget()) {
             this.parameters.push('-debug');
             defines.push('sys_debug_html5');
             defines.push('kha_debug_html5');
@@ -109,6 +112,17 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
                 targetOptions.scriptName = userOptions.scriptName;
         }
         fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
+        if (this.isADebugTarget()) {
+            let electron = path.join(this.options.to, this.sysdir(), 'electron.js');
+            let protoelectron = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'electron.js'), { encoding: 'utf8' });
+            protoelectron = protoelectron.replace(/{Width}/g, '' + this.width);
+            protoelectron = protoelectron.replace(/{Height}/g, '' + this.height);
+            fs.writeFileSync(electron.toString(), protoelectron);
+            let pack = path.join(this.options.to, this.sysdir(), 'package.json');
+            let protopackage = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'package.json'), { encoding: 'utf8' });
+            protopackage = protopackage.replace(/{Name}/g, name);
+            fs.writeFileSync(pack.toString(), protopackage);
+        }
         if (this.isDebugHtml5()) {
             let index = path.join(this.options.to, this.sysdir(), 'index.html');
             let protoindex = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'index.html'), { encoding: 'utf8' });
@@ -118,15 +132,6 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
             protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
             protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
             fs.writeFileSync(index.toString(), protoindex);
-            let pack = path.join(this.options.to, this.sysdir(), 'package.json');
-            let protopackage = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'package.json'), { encoding: 'utf8' });
-            protopackage = protopackage.replace(/{Name}/g, name);
-            fs.writeFileSync(pack.toString(), protopackage);
-            let electron = path.join(this.options.to, this.sysdir(), 'electron.js');
-            let protoelectron = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'electron.js'), { encoding: 'utf8' });
-            protoelectron = protoelectron.replace(/{Width}/g, '' + this.width);
-            protoelectron = protoelectron.replace(/{Height}/g, '' + this.height);
-            fs.writeFileSync(electron.toString(), protoelectron);
         }
         else if (this.isNode()) {
             let pack = path.join(this.options.to, this.sysdir(), 'package.json');

--- a/out/main.js
+++ b/out/main.js
@@ -302,7 +302,7 @@ async function exportKhaProject(options) {
             if (target.endsWith('-hl')) {
                 korehl = true;
                 options.target = koreplatform(target);
-                if (!checkKorePlatform(options.target)) {
+                if (!checkKorePlatform(baseTarget)) {
                     log.error('Unknown platform: ' + options.target);
                     return Promise.reject('');
                 }
@@ -312,7 +312,7 @@ async function exportKhaProject(options) {
                 kore = true;
                 // If target is 'android-native' then options.target becomes 'android'
                 options.target = koreplatform(target);
-                if (!checkKorePlatform(options.target)) {
+                if (!checkKorePlatform(baseTarget)) {
                     log.error('Unknown platform: ' + options.target);
                     return Promise.reject('');
                 }
@@ -386,7 +386,7 @@ async function exportKhaProject(options) {
                 }
             }
         }
-        let shaderCompiler = new ShaderCompiler_1.ShaderCompiler(exporter, options.target, options.krafix, shaderDir, temp, buildDir, options, project.shaderMatchers);
+        let shaderCompiler = new ShaderCompiler_1.ShaderCompiler(exporter, baseTarget, options.krafix, shaderDir, temp, buildDir, options, project.shaderMatchers);
         lastShaderCompiler = shaderCompiler;
         try {
             exportedShaders = await shaderCompiler.run(options.watch, recompileAllShaders);

--- a/out/main.js
+++ b/out/main.js
@@ -299,11 +299,11 @@ async function exportKhaProject(options) {
             exporter = new EmptyExporter_1.EmptyExporter(options);
             break;
         default:
-            if (target.endsWith('-hl')) {
+            if (baseTarget.endsWith('-hl')) {
                 korehl = true;
-                options.target = koreplatform(target);
+                options.target = koreplatform(baseTarget);
                 if (!checkKorePlatform(baseTarget)) {
-                    log.error('Unknown platform: ' + options.target);
+                    log.error(`Unknown platform: ${target} (baseTarget=$${baseTarget})`);
                     return Promise.reject('');
                 }
                 exporter = new KoreHLExporter_1.KoreHLExporter(options);
@@ -311,9 +311,9 @@ async function exportKhaProject(options) {
             else {
                 kore = true;
                 // If target is 'android-native' then options.target becomes 'android'
-                options.target = koreplatform(target);
+                options.target = koreplatform(baseTarget);
                 if (!checkKorePlatform(baseTarget)) {
-                    log.error('Unknown platform: ' + options.target);
+                    log.error(`Unknown platform: ${target} (baseTarget=$${baseTarget})`);
                     return Promise.reject('');
                 }
                 exporter = new KoreExporter_1.KoreExporter(options);

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -97,6 +97,10 @@ export class Html5Exporter extends KhaExporter {
 
 			defines.push('kha_' + this.options.target);
 			defines.push('kha_' + this.options.target + '_js');
+
+			defines.push('sys_html5');
+			defines.push('kha_html5');
+			defines.push('kha_html5_js');
 		}
 
 		if (this.isADebugTarget()) {

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -20,6 +20,10 @@ export class Html5Exporter extends KhaExporter {
 		return 'HTML5';
 	}
 
+	isADebugTarget() {
+		return this.sysdir().indexOf('debug') !== -1;
+	}
+
 	isDebugHtml5() {
 		return this.sysdir() === 'debug-html5';
 	}
@@ -95,7 +99,7 @@ export class Html5Exporter extends KhaExporter {
 			defines.push('kha_' + this.options.target + '_js');
 		}
 
-		if (this.isDebugHtml5()) {
+		if (this.isADebugTarget()) {
 			this.parameters.push('-debug');
 
 			defines.push('sys_debug_html5');
@@ -139,6 +143,19 @@ export class Html5Exporter extends KhaExporter {
 
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir()));
 
+		if (this.isADebugTarget()) {
+			let electron = path.join(this.options.to, this.sysdir(), 'electron.js');
+			let protoelectron = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'electron.js'), {encoding: 'utf8'});
+			protoelectron = protoelectron.replace(/{Width}/g, '' + this.width);
+			protoelectron = protoelectron.replace(/{Height}/g, '' + this.height);
+			fs.writeFileSync(electron.toString(), protoelectron);
+
+			let pack = path.join(this.options.to, this.sysdir(), 'package.json');
+			let protopackage = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'package.json'), {encoding: 'utf8'});
+			protopackage = protopackage.replace(/{Name}/g, name);
+			fs.writeFileSync(pack.toString(), protopackage);
+		}
+
 		if (this.isDebugHtml5()) {
 			let index = path.join(this.options.to, this.sysdir(), 'index.html');
 
@@ -149,17 +166,6 @@ export class Html5Exporter extends KhaExporter {
 			protoindex = protoindex.replace(/{CanvasId}/g, '' + targetOptions.canvasId);
 			protoindex = protoindex.replace(/{ScriptName}/g, '' + targetOptions.scriptName);
 			fs.writeFileSync(index.toString(), protoindex);
-
-			let pack = path.join(this.options.to, this.sysdir(), 'package.json');
-			let protopackage = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'package.json'), {encoding: 'utf8'});
-			protopackage = protopackage.replace(/{Name}/g, name);
-			fs.writeFileSync(pack.toString(), protopackage);
-
-			let electron = path.join(this.options.to, this.sysdir(), 'electron.js');
-			let protoelectron = fs.readFileSync(path.join(__dirname, '..', '..', 'Data', 'debug-html5', 'electron.js'), {encoding: 'utf8'});
-			protoelectron = protoelectron.replace(/{Width}/g, '' + this.width);
-			protoelectron = protoelectron.replace(/{Height}/g, '' + this.height);
-			fs.writeFileSync(electron.toString(), protoelectron);
 		}
 		else if (this.isNode()) {
 			let pack = path.join(this.options.to, this.sysdir(), 'package.json');

--- a/src/main.ts
+++ b/src/main.ts
@@ -331,11 +331,11 @@ async function exportKhaProject(options: Options): Promise<string> {
 			exporter = new EmptyExporter(options);
 			break;
 		default:
-			if (target.endsWith('-hl')) {
+			if (baseTarget.endsWith('-hl')) {
 				korehl = true;
-				options.target = koreplatform(target);
+				options.target = koreplatform(baseTarget);
 				if (!checkKorePlatform(baseTarget)) {
-					log.error('Unknown platform: ' + options.target);
+					log.error(`Unknown platform: ${target} (baseTarget=$${baseTarget})`);
 					return Promise.reject('');
 				}
 				exporter = new KoreHLExporter(options);
@@ -343,9 +343,9 @@ async function exportKhaProject(options: Options): Promise<string> {
 			else {
 				kore = true;
 				// If target is 'android-native' then options.target becomes 'android'
-				options.target = koreplatform(target);
+				options.target = koreplatform(baseTarget);
 				if (!checkKorePlatform(baseTarget)) {
-					log.error('Unknown platform: ' + options.target);
+					log.error(`Unknown platform: ${target} (baseTarget=$${baseTarget})`);
 					return Promise.reject('');
 				}
 				exporter = new KoreExporter(options);

--- a/src/main.ts
+++ b/src/main.ts
@@ -334,7 +334,7 @@ async function exportKhaProject(options: Options): Promise<string> {
 			if (target.endsWith('-hl')) {
 				korehl = true;
 				options.target = koreplatform(target);
-				if (!checkKorePlatform(options.target)) {
+				if (!checkKorePlatform(baseTarget)) {
 					log.error('Unknown platform: ' + options.target);
 					return Promise.reject('');
 				}
@@ -344,7 +344,7 @@ async function exportKhaProject(options: Options): Promise<string> {
 				kore = true;
 				// If target is 'android-native' then options.target becomes 'android'
 				options.target = koreplatform(target);
-				if (!checkKorePlatform(options.target)) {
+				if (!checkKorePlatform(baseTarget)) {
 					log.error('Unknown platform: ' + options.target);
 					return Promise.reject('');
 				}
@@ -433,7 +433,7 @@ async function exportKhaProject(options: Options): Promise<string> {
 			}
 		}
 
-		let shaderCompiler = new ShaderCompiler(exporter, options.target, options.krafix, shaderDir, temp,
+		let shaderCompiler = new ShaderCompiler(exporter, baseTarget, options.krafix, shaderDir, temp,
 		buildDir, options, project.shaderMatchers);
 		lastShaderCompiler = shaderCompiler;
 		try {


### PR DESCRIPTION
Edit: Technically, you can already do all that by including the required files (khamake/Data/debug-html5/*) into your build folder and add some defines by hand, but i think it's a bit more convenient to have it done automatically.

With this PR it's possible to define custom debug-html5 targets. We need that to build with different preloaders and whatnot. How to use it:

### khafile.js

- the target must have `debug` in it's name
- export custom html files in case you need it

```js
project.addTarget('debug-foo', 'debug-html5', ['debug-html5']);

switch (platform) {
	case 'debug-foo': case 'foo': {
		project.addAssets('assets-foo/**', {
			notinlist: true,
			nameBaseDir: 'assets-foo',
			destination: '{dir}/{name}',
			name: '{dir}/{name}'
		});
		project.targetOptions.html5.scriptName = 'foo';
	} break;
}
```

### .vscode/tasks.json

- add a custom build task

```json
        {
            "command": "node",
            "label": "Khastom: Build for Debug Foo",
            "type": "shell",
            "args": [
                "Kha/make",
                "--target",
                "debug-foo",
                "--parallelAssetConversion",
                "9",
                "--ffmpeg",
                "node_modules/@sh-dave/ffmpeg-binaries/bin/ffmpeg"
            ],
            "problemMatcher": [
                "$haxe-absolute",
                "$haxe"
            ],
            "group": {
                "kind": "build",
                "isDefault": true
            }
        },
```

### .vscode/lauch.json

- add a custom launch task

```json
        {
            "type": "electron",
            "request": "launch",
            "name": "Khastom: Debug Foo",
            "appDir": "${workspaceFolder}/build/debug-foo",
            "cwd": "${workspaceFolder}/build/debug-foo",
            "sourceMaps": true,
            "preLaunchTask": "Khastom: Build for Debug Foo",
            "internalConsoleOptions": "openOnSessionStart"
        },
```
