### PR TITLE
suppress overwrite prompt

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -583,7 +583,7 @@ async function run(options, loglog) {
             options.krafix = krafixpath;
     }
     if (!options.ogg && options.ffmpeg) {
-        options.ogg = options.ffmpeg + ' -nostdin -i {in} {out}';
+        options.ogg = options.ffmpeg + ' -nostdin -i {in} {out} -y';
     }
     if (!options.mp3 && options.ffmpeg) {
         options.mp3 = options.ffmpeg + ' -nostdin -i {in} {out}';

--- a/src/main.ts
+++ b/src/main.ts
@@ -651,7 +651,7 @@ export async function run(options: Options, loglog: any): Promise<string> {
 	}
 
 	if (!options.ogg && options.ffmpeg) {
-		options.ogg = options.ffmpeg + ' -nostdin -i {in} {out}';
+		options.ogg = options.ffmpeg + ' -nostdin -i {in} {out} -y';
 	}
 
 	if (!options.mp3 && options.ffmpeg) {


### PR DESCRIPTION
In case an `ogg` already existed but should still be overwritten for whatever reason, ffmpeg will create an `Do you want to overwrite [y/N]` prompt, that in turn will crash khamake. Now the files are always overwritten.
