### PR TITLE
use target as root directory when running --server

### DIFF
--- a/out/khamake.js
+++ b/out/khamake.js
@@ -347,7 +347,7 @@ if (parsedOptions.init) {
 else if (parsedOptions.server) {
     console.log('Running server on ' + parsedOptions.port);
     let nstatic = require('node-static');
-    let fileServer = new nstatic.Server(path.join(parsedOptions.from, 'build', 'html5'), { cache: 0 });
+    let fileServer = new nstatic.Server(path.join(parsedOptions.from, 'build', parsedOptions.target), { cache: 0 });
     let server = require('http').createServer(function (request, response) {
         request.addListener('end', function () {
             fileServer.serve(request, response);

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -353,7 +353,7 @@ if (parsedOptions.init) {
 else if (parsedOptions.server) {
 	console.log('Running server on ' + parsedOptions.port);
 	let nstatic = require('node-static');
-	let fileServer = new nstatic.Server(path.join(parsedOptions.from, 'build', 'html5'), { cache: 0 });
+	let fileServer = new nstatic.Server(path.join(parsedOptions.from, 'build', parsedOptions.target), { cache: 0 });
 	let server = require('http').createServer(function (request: any, response: any) {
 		request.addListener('end', function () {
 			fileServer.serve(request, response);


### PR DESCRIPTION
This will set the target name as root directory when running with the `--server` option, instead of forcing it to `html5`. Custom html5-based targets can serve now as well.