### PR TITLE
Symlinks

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -58,7 +58,7 @@ class AssetConverter {
         return new Promise((resolve, reject) => {
             let ready = false;
             let files = [];
-            this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch });
+            this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch, followSymlinks: false });
             const onFileChange = (file) => {
                 const fileinfo = path.parse(file);
                 const baseDir = path.dirname(match);

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -193,7 +193,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         return [to + '.' + format];
     }
     async copyBlob(platform, from, to, options) {
-        fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
+        fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true, dereference: true });
         return [to];
     }
     async copyVideo(platform, from, to, options) {

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -76,7 +76,7 @@ export class AssetConverter {
 		return new Promise<{ name: string, from: string, type: string, files: string[], original_width: number, original_height: number, readable: boolean }[]>((resolve, reject) => {
 			let ready = false;
 			let files: string[] = [];
-			this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch });
+			this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch, followSymlinks: false });
 
 			const onFileChange = (file: string) => {
 				const fileinfo = path.parse(file);

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -230,7 +230,7 @@ export class Html5Exporter extends KhaExporter {
 	}
 
 	async copyBlob(platform: string, from: string, to: string, options: any) {
-		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
+		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true, dereference: true });
 		return [to];
 	}
 


### PR DESCRIPTION
another one of the `maybe only me` PR's. this will improve symbolic link handling during asset conversion a bit.

1) if you have a broken symlink in the assets folder, chokidar will just explode and skip the entire folder; fixed in 994216818299c0ce82c475a87fc7909a27a72c07

2) and since windows10, symlinks are available on windows as well, but copying them during asset conversion will result in something broken. with 8fb13f69874f10c6df1e26eb9d71eddf790b4ddc the  linked content will now be copied instead