### PR TITLE
allow custom debug-html5 based targets to omit `debug` in their name

### DIFF
--- a/out/Exporters/DebugHtml5Exporter.js
+++ b/out/Exporters/DebugHtml5Exporter.js
@@ -4,6 +4,7 @@ const Html5Exporter_1 = require("./Html5Exporter");
 class DebugHtml5Exporter extends Html5Exporter_1.Html5Exporter {
     constructor(options) {
         super(options);
+        this.isDebug = true;
     }
 }
 exports.DebugHtml5Exporter = DebugHtml5Exporter;

--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -14,7 +14,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         return 'HTML5';
     }
     isADebugTarget() {
-        return this.sysdir().indexOf('debug') !== -1;
+        return this.isDebug;
     }
     isDebugHtml5() {
         return this.sysdir() === 'debug-html5';
@@ -173,7 +173,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         let ogg = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.ogg'), this.options.ogg);
         let mp4 = false;
         let mp3 = false;
-        if (!this.isDebugHtml5()) {
+        if (!this.isADebugTarget()) {
             mp4 = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.aac);
             if (!mp4) {
                 mp3 = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.mp3'), this.options.mp3);
@@ -199,7 +199,7 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
     async copyVideo(platform, from, to, options) {
         fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
         let mp4 = false;
-        if (!this.isDebugHtml5()) {
+        if (!this.isADebugTarget()) {
             mp4 = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.h264);
         }
         let webm = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.webm'), this.options.webm);

--- a/src/Exporters/DebugHtml5Exporter.ts
+++ b/src/Exporters/DebugHtml5Exporter.ts
@@ -4,5 +4,6 @@ import {Options} from '../Options';
 export class DebugHtml5Exporter extends Html5Exporter {
 	constructor(options: Options) {
 		super(options);
+		this.isDebug = true;
 	}
 }

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -11,6 +11,7 @@ import {VrApi} from '../VrApi';
 export class Html5Exporter extends KhaExporter {
 	width: number;
 	height: number;
+	isDebug: boolean;
 
 	constructor(options: Options) {
 		super(options);
@@ -21,7 +22,7 @@ export class Html5Exporter extends KhaExporter {
 	}
 
 	isADebugTarget() {
-		return this.sysdir().indexOf('debug') !== -1;
+		return this.isDebug;
 	}
 
 	isDebugHtml5() {
@@ -211,7 +212,7 @@ export class Html5Exporter extends KhaExporter {
 		let ogg = await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogg'), this.options.ogg);
 		let mp4 = false;
 		let mp3 = false;
-		if (!this.isDebugHtml5()) {
+		if (!this.isADebugTarget()) {
 			mp4 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.aac);
 			if (!mp4) {
 				mp3 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp3'), this.options.mp3);
@@ -237,7 +238,7 @@ export class Html5Exporter extends KhaExporter {
 	async copyVideo(platform: string, from: string, to: string, options: any) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		let mp4 = false;
-		if (!this.isDebugHtml5()) {
+		if (!this.isADebugTarget()) {
 			mp4 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.h264);
 		}
 		let webm = await convert(from, path.join(this.options.to, this.sysdir(), to + '.webm'), this.options.webm);


### PR DESCRIPTION
instead of parsing the output path, the debug flag is now set in the DebugHtml5Exporter