### PR TITLE
Improve (re)export

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -64,9 +64,14 @@ class AssetConverter {
             this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch, followSymlinks: false });
             const onFileChange = (file) => {
                 const fileinfo = path.parse(file);
-                const baseDir = path.dirname(match);
                 let outPath = fileinfo.dir + path.sep + fileinfo.name;
-                outPath = path.relative(baseDir, outPath);
+                // with subfolders
+                if (options.destination != null) {
+                    outPath = path.relative(options.baseDir, outPath);
+                }
+                else { // flat
+                    outPath = fileinfo.name;
+                }
                 log.info('Reexporting ' + outPath + fileinfo.ext);
                 switch (fileinfo.ext) {
                     case '.png':

--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -31,7 +31,7 @@ class HaxeCompiler {
     }
     async run(watch) {
         if (watch) {
-            this.watcher = chokidar.watch(this.sourceMatchers, { ignored: /[\/\\]\.git/, persistent: true, ignoreInitial: true });
+            this.watcher = chokidar.watch(this.sourceMatchers, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: true, ignoreInitial: true });
             this.watcher.on('add', (file) => {
                 this.scheduleCompile();
             });

--- a/out/ShaderCompiler.js
+++ b/out/ShaderCompiler.js
@@ -156,7 +156,7 @@ class ShaderCompiler {
         return new Promise((resolve, reject) => {
             let shaders = [];
             let ready = false;
-            this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.git/, persistent: watch });
+            this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch });
             this.watcher.on('add', (filepath) => {
                 let file = path.parse(filepath);
                 if (ready) {

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -84,9 +84,14 @@ export class AssetConverter {
 
 			const onFileChange = (file: string) => {
 				const fileinfo = path.parse(file);
-				const baseDir = path.dirname(match);
 				let outPath = fileinfo.dir + path.sep + fileinfo.name;
-				outPath = path.relative(baseDir, outPath);
+				// with subfolders
+				if (options.destination != null) {
+					outPath = path.relative(options.baseDir, outPath);
+				}
+				else { // flat
+					outPath = fileinfo.name;
+				}
 				log.info('Reexporting ' + outPath + fileinfo.ext);
 				switch (fileinfo.ext) {
 					case '.png':

--- a/src/HaxeCompiler.ts
+++ b/src/HaxeCompiler.ts
@@ -42,7 +42,7 @@ export class HaxeCompiler {
 
 	async run(watch: boolean) {
 		if (watch) {
-			this.watcher = chokidar.watch(this.sourceMatchers, { ignored: /[\/\\]\.git/, persistent: true, ignoreInitial: true });
+			this.watcher = chokidar.watch(this.sourceMatchers, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: true, ignoreInitial: true });
 			this.watcher.on('add', (file: string) => {
 				this.scheduleCompile();
 			});

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -103,9 +103,26 @@ export class Project {
 		const globChars = ['\\@', '\\!', '\\+', '\\*', '\\?', '\\(', '\\[', '\\{', '\\)', '\\]', '\\}'];
 		str = str.replace(/\\/g, '/');
 		for (const char of globChars) {
-			str = str.replace(new RegExp(char, 'g'), '\\' + char.substr(1));
+			str = str.replace(new RegExp(char, 'g'), char);
 		}
 		return str;
+	}
+
+	private getBaseDir(str: string): string {
+		// replace \\ to / if next char is not glob
+		str = str.replace(/\\([^@!+*?{}()[\]]|$)/g, '/$1');
+		// find non-globby path part
+		const globby = /[^\\][@!+*?{}()[\]]/;
+		while (globby.test(str)) {
+			str = path.dirname(str);
+		}
+		str = this.removeGlobEscaping(str);
+		if (!str.endsWith('/')) str += '/';
+		return str;
+	}
+
+	private removeGlobEscaping(str: string): string {
+		return str.replace(/\\([@!+*?{}()[\]]|$)/g, '$1');
 	}
 
 	/**
@@ -118,10 +135,14 @@ export class Project {
 
 		if (!path.isAbsolute(match)) {
 			let base = this.unglob(path.resolve(this.scriptdir));
-			if (!base.endsWith('/')) {
-				base += '/';
-			}
-			match = base + match.replace(/\\/g, '/');
+			if (!base.endsWith('/')) base += '/';
+			// if there is no nameBaseDir: extract relative assets path from match
+			const baseName = options.nameBaseDir == null ? this.getBaseDir(match) : options.nameBaseDir;
+			match = path.resolve(base, match.replace(/\\/g, '/'));
+			options.baseDir = path.resolve(this.removeGlobEscaping(base), baseName);
+		}
+		else {
+			options.baseDir = this.getBaseDir(match);
 		}
 
 		this.assetMatchers.push({ match: match, options: options });

--- a/src/ShaderCompiler.ts
+++ b/src/ShaderCompiler.ts
@@ -181,7 +181,7 @@ export class ShaderCompiler {
 		return new Promise<CompiledShader[]>((resolve, reject) => {
 			let shaders: string[] = [];
 			let ready = false;
-			this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.git/, persistent: watch });
+			this.watcher = chokidar.watch(match, { ignored: /[\/\\]\.(git|DS_Store)/, persistent: watch });
 			this.watcher.on('add', (filepath: string) => {
 				let file = path.parse(filepath);
 				if (ready) {


### PR DESCRIPTION
Fixes #193, related to #191
Tested cases (with updated chokidar):
```js
project.addAssets('res/**');

project.addAssets('res/human.json');
project.addAssets('res/sub/subhuman.json');

project.addAssets('res/**', {
	nameBaseDir: 'res',
	destination: '{dir}/{name}',
	name: '{dir}/{name}'
});

// only subfolders
project.addAssets('res/*/**', {
	quality: 0.5,
	nameBaseDir: 'res',
	destination: '{dir}/{name}',
	name: '{dir}/{name}'
});

project.addAssets('res/**/!(*.mp3)', {
	nameBaseDir: 'res',
	destination: '{dir}/{name}',
	name: '{dir}/{name}'
});

project.addAssets('../res/**');

project.addAssets('../res/**/!(*.mp3)');

project.addAssets('../res/**/!(*.mp3)', {
	nameBaseDir: '../res',
	destination: '{dir}/{name}',
	name: '{dir}/{name}'
});

project.addAssets('/Users/resman/Downloads/res/**');
```