### PR TITLE
updated files.json spec to include file sizes

### DIFF
--- a/src/Exporters/AndroidExporter.ts
+++ b/src/Exporters/AndroidExporter.ts
@@ -152,25 +152,25 @@ export class AndroidExporter extends KhaExporter {
 		if (options.quality < 1) {
 			fs.ensureDirSync(path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', path.dirname(to)));
 			let ogg = await convert(from, path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.ogg'), this.options.ogg);
-			return [to + '.ogg'];
+			return { files: [to + '.ogg'], sizes: [1] };
 		}
 		else {
 			fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to + '.wav'), { overwrite: true });
-			return [to + '.wav'];
+			return { files: [to + '.wav'], sizes: [1] };
 		}
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to), asset, undefined, false, false, cache);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), this.safename, 'app', 'src', 'main', 'assets', to), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 }

--- a/src/Exporters/CSharpExporter.ts
+++ b/src/Exporters/CSharpExporter.ts
@@ -102,20 +102,20 @@ export abstract class CSharpExporter extends KhaExporter {
 	abstract exportResources(): void;
 
 	async copySound(platform: string, from: string, to: string) {
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), asset, undefined, false, false, cache);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from, path.join(this.options.to, this.sysdir(), to), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 }

--- a/src/Exporters/EmptyExporter.ts
+++ b/src/Exporters/EmptyExporter.ts
@@ -71,18 +71,18 @@ export class EmptyExporter extends KhaExporter {
 	}
 
 	async copySound(platform: string, from: string, to: string) {
-		return [''];
+		return { files: [''], sizes: [0] };
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any) {
-		return [''];
+		return { files: [''], sizes: [0] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
-		return [''];
+		return { files: [''], sizes: [0] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
-		return [''];
+		return { files: [''], sizes: [0] };
 	}
 }

--- a/src/Exporters/FlashExporter.ts
+++ b/src/Exporters/FlashExporter.ts
@@ -121,25 +121,25 @@ export class FlashExporter extends KhaExporter {
 	async copySound(platform: string, from: string, to: string) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp3'), this.options.mp3);
-		return [to + '.mp3'];
+		return { files: [to + '.mp3'], sizes: [1] };
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), asset, undefined, false, false, cache);
 		if (this.options.embedflashassets) this.images.push(to + '.' + format);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
 		if (this.options.embedflashassets) this.blobs.push(to);
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.h264);
-		return [to + '.mp4'];
+		return { files: [to + '.mp4'], sizes: [1] };
 	}
 
 	addShader(shader: string) {

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -210,41 +210,55 @@ export class Html5Exporter extends KhaExporter {
 	async copySound(platform: string, from: string, to: string,  options: any) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		let ogg = await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogg'), this.options.ogg);
+		let ogg_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.ogg'))).size;
 		let mp4 = false;
+		let mp4_size = 0;
 		let mp3 = false;
+		let mp3_size = 0;
 		if (!this.isADebugTarget()) {
 			mp4 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.aac);
+			mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
 			if (!mp4) {
 				mp3 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp3'), this.options.mp3);
+				mp3_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
 			}
 		}
 		let files: string[] = [];
-		if (ogg) files.push(to + '.ogg');
-		if (mp4) files.push(to + '.mp4');
-		if (mp3) files.push(to + '.mp3');
-		return files;
+		let sizes: number[] = [];
+		if (ogg) { files.push(to + '.ogg'); sizes.push(ogg_size); }
+		if (mp4) { files.push(to + '.mp4'); sizes.push(mp4_size); }
+		if (mp3) { files.push(to + '.mp3'); sizes.push(mp3_size); }
+		return { files: files, sizes: sizes };
 	}
 
 	async copyImage(platform: string, from: string, to: string, options: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, undefined, false, false, cache);
-		return [to + '.' + format];
+		let stat = await fs.stat(path.join(this.options.to, this.sysdir(), to + '.' + format));
+		let size = stat.size;
+		return { files: [to + '.' + format], sizes: [size]};
 	}
 
 	async copyBlob(platform: string, from: string, to: string, options: any) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true, dereference: true });
-		return [to];
+		let stat = await fs.stat(path.join(this.options.to, this.sysdir(), to));
+		let size = stat.size;
+		return { files: [to], sizes: [size]};
 	}
 
 	async copyVideo(platform: string, from: string, to: string, options: any) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		let mp4 = false;
+		let mp4_size = 0;
 		if (!this.isADebugTarget()) {
 			mp4 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.h264);
+			mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
 		}
 		let webm = await convert(from, path.join(this.options.to, this.sysdir(), to + '.webm'), this.options.webm);
+		let webm_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.webm'))).size;
 		let files: string[] = [];
-		if (mp4) files.push(to + '.mp4');
-		if (webm) files.push(to + '.webm');
-		return files;
+		let sizes: number[] = [];
+		if (mp4) { files.push(to + '.mp4'); sizes.push(mp4_size); }
+		if (webm) { files.push(to + '.webm'); sizes.push(webm_size); }
+		return { files: files, sizes: sizes };
 	}
 }

--- a/src/Exporters/JavaExporter.ts
+++ b/src/Exporters/JavaExporter.ts
@@ -98,20 +98,20 @@ export class JavaExporter extends KhaExporter {
 
 	async copySound(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to + '.wav'), { overwrite: true });
-		return [to + '.wav'];
+		return { files: [to + '.wav'], sizes: [1] };
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), asset, undefined, false, false, cache);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 }

--- a/src/Exporters/KhaExporter.ts
+++ b/src/Exporters/KhaExporter.ts
@@ -75,23 +75,23 @@ export abstract class KhaExporter extends Exporter {
 		}
 	}
 
-	async copyImage(platform: string, from: string, to: string, options: any, cache: any): Promise<Array<string>> {
-		return [];
+	async copyImage(platform: string, from: string, to: string, options: any, cache: any): Promise<{ files: Array<string>, sizes: Array<number>}> {
+		return {files: [], sizes: []};
 	}
 
-	async copySound(platform: string, from: string, to: string, options: any): Promise<Array<string>> {
-		return [];
+	async copySound(platform: string, from: string, to: string, options: any): Promise<{ files: Array<string>, sizes: Array<number>}> {
+		return {files: [], sizes: []};
 	}
 
-	async copyVideo(platform: string, from: string, to: string, options: any): Promise<Array<string>> {
-		return [];
+	async copyVideo(platform: string, from: string, to: string, options: any): Promise<{ files: Array<string>, sizes: Array<number>}> {
+		return {files: [], sizes: []};
 	}
 
-	async copyBlob(platform: string, from: string, to: string, options: any): Promise<Array<string>> {
-		return [];
+	async copyBlob(platform: string, from: string, to: string, options: any): Promise<{ files: Array<string>, sizes: Array<number>}> {
+		return {files: [], sizes: []};
 	}
 
-	async copyFont(platform: string, from: string, to: string, options: any): Promise<Array<string>> {
+	async copyFont(platform: string, from: string, to: string, options: any): Promise<{ files: Array<string>, sizes: Array<number>}> {
 		return await this.copyBlob(platform, from, to + '.ttf', options);
 	}
 }

--- a/src/Exporters/KoreExporter.ts
+++ b/src/Exporters/KoreExporter.ts
@@ -89,7 +89,7 @@ export class KoreExporter extends KhaExporter {
 		if (options.quality < 1) {
 			fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogg'), this.options.ogg);
-			return [to + '.ogg'];
+			return { files: [to + '.ogg'], sizes: [1] };
 		}
 		else {
 			if (from.endsWith('.wav')) {
@@ -98,48 +98,48 @@ export class KoreExporter extends KhaExporter {
 			else {
 				throw 'Can not convert ' + from + ' to wav format.';
 			}
-			return [to + '.wav'];
+			return { files: [to + '.wav'], sizes: [1] };
 		}
 	}
 
 	async copyImage(platform: string, from: string, to: string, options: any, cache: any) {
 		if (platform === Platform.iOS && options.quality < 1) {
 			let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'pvr', true, false, cache);
-			return [to + '.' + format];
+			return { files: [to + '.' + format], sizes: [1] };
 		}
 		else if (platform === Platform.Windows && options.quality < 1 && (this.options.graphics === GraphicsApi.OpenGL || this.options.graphics === GraphicsApi.Vulkan)) {
 			// let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'ASTC', true, false, cache);
 			let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'DXT5', true, false, cache);
-			return [to + '.' + format];
+			return { files: [to + '.' + format], sizes: [1] };
 		}
 		else {
 			let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'lz4', true, false, cache);
-			return [to + '.' + format];
+			return { files: [to + '.' + format], sizes: [1] };
 		}
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		if (platform === Platform.Windows) {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.avi'), this.options.h264);
-			return [to + '.avi'];
+			return { files: [to + '.avi'], sizes: [1] };
 		}
 		else if (platform === Platform.iOS || platform === Platform.OSX) {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.h264);
-			return [to + '.mp4'];
+			return { files: [to + '.mp4'], sizes: [1] };
 		}
 		else if (platform === Platform.Android) {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.ts'), this.options.h264);
-			return [to + '.ts'];
+			return { files: [to + '.ts'], sizes: [1] };
 		}
 		else {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogv'), this.options.theora);
-			return [to + '.ogv'];
+			return { files: [to + '.ogv'], sizes: [1] };
 		}
 	}
 }

--- a/src/Exporters/KoreHLExporter.ts
+++ b/src/Exporters/KoreHLExporter.ts
@@ -85,52 +85,52 @@ export class KoreHLExporter extends KhaExporter {
 		if (options.quality < 1) {
 			fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 			let ogg = await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogg'), this.options.ogg);
-			return [to + '.ogg'];
+			return { files: [to + '.ogg'], sizes: [1] };
 		}
 		else {
 			fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to + '.wav'), { overwrite: true });
-			return [to + '.wav'];
+			return { files: [to + '.wav'], sizes: [1] };
 		}
 	}
 
 	async copyImage(platform: string, from: string, to: string, options: any, cache: any) {
 		if (platform === Platform.iOS && options.quality < 1) {
 			let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'pvr', true, false, cache);
-			return [to + '.' + format];
+			return { files: [to + '.' + format], sizes: [1] };
 		}
 		else if (platform === Platform.Windows && options.quality < 1 && (this.options.graphics === GraphicsApi.OpenGL || this.options.graphics === GraphicsApi.Vulkan)) {
 			// let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'ASTC', true, false, cache);
 			let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'DXT5', true, false, cache);
-			return [to + '.' + format];
+			return { files: [to + '.' + format], sizes: [1] };
 		}
 		else {
 			let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, 'lz4', true, false, cache);
-			return [to + '.' + format];
+			return { files: [to + '.' + format], sizes: [1] };
 		}
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to).toString(), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		if (platform === Platform.Windows) {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.avi'), this.options.h264);
-			return [to + '.avi'];
+			return { files: [to + '.avi'], sizes: [1] };
 		}
 		else if (platform === Platform.iOS || platform === Platform.OSX) {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.h264);
-			return [to + '.mp4'];
+			return { files: [to + '.mp4'], sizes: [1] };
 		}
 		else if (platform === Platform.Android) {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.ts'), this.options.h264);
-			return [to + '.ts'];
+			return { files: [to + '.ts'], sizes: [1] };
 		}
 		else {
 			await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogv'), this.options.theora);
-			return [to + '.ogv'];
+			return { files: [to + '.ogv'], sizes: [1] };
 		}
 	}
 }

--- a/src/Exporters/KromExporter.ts
+++ b/src/Exporters/KromExporter.ts
@@ -76,29 +76,30 @@ export class KromExporter extends KhaExporter {
 		if (options.quality < 1) {
 			fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 			let ogg = await convert(from, path.join(this.options.to, this.sysdir(), to + '.ogg'), this.options.ogg);
-			return [to + '.ogg'];
+			return { files: [to + '.ogg'], sizes: [1] };
 		}
 		else {
 			fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to + '.wav'), { overwrite: true });
-			return [to + '.wav'];
+			return { files: [to + '.wav'], sizes: [1] };
 		}
 	}
 
 	async copyImage(platform: string, from: string, to: string, options: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), options, undefined, false, false, cache);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		let webm = await convert(from, path.join(this.options.to, this.sysdir(), to + '.webm'), this.options.webm);
 		let files: string[] = [];
-		if (webm) files.push(to + '.webm');
-		return files;
+		let sizes: number[] = [];
+		if (webm) { files.push(to + '.webm'); sizes.push(1); }
+		return { files: files, sizes: sizes };
 	}
 }

--- a/src/Exporters/PlayStationMobileExporter.ts
+++ b/src/Exporters/PlayStationMobileExporter.ts
@@ -144,22 +144,22 @@ export class PlayStationMobileExporter extends CSharpExporter {
 	}*/
 
 	async copySound(platform: string, from: string, to: string) {
-		return [''];
+		return { files: [''], sizes: [1] };
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {
 		this.files.push(asset['file']);
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), to), asset, undefined, false, false, cache);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to), { overwrite: true });
 		this.files.push(to);
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
-		return [''];
+		return { files: [''], sizes: [1] };
 	}
 }

--- a/src/Exporters/UnityExporter.ts
+++ b/src/Exporters/UnityExporter.ts
@@ -79,20 +79,20 @@ export class UnityExporter extends KhaExporter {
 
 	async copySound(platform: string, from: string, to: string) {
 		let ogg = await convert(from, path.join(this.options.to, this.sysdir(), 'Assets', 'Resources', 'Sounds', to + '.ogg'), this.options.ogg);
-		return [to + '.ogg'];
+		return { files: [to + '.ogg'], sizes: [1] };
 	}
 
 	async copyImage(platform: string, from: string, to: string, asset: any, cache: any) {
 		let format = await exportImage(this.options.kha, from, path.join(this.options.to, this.sysdir(), 'Assets', 'Resources', 'Images', to), asset, undefined, false, true, cache);
-		return [to + '.' + format];
+		return { files: [to + '.' + format], sizes: [1] };
 	}
 
 	async copyBlob(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), 'Assets', 'Resources', 'Blobs', to + '.bytes'), { overwrite: true });
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
-		return [to];
+		return { files: [to], sizes: [1] };
 	}
 }

--- a/src/Exporters/WpfExporter.ts
+++ b/src/Exporters/WpfExporter.ts
@@ -276,12 +276,12 @@ export class WpfExporter extends CSharpExporter {
 
 	async copySound(platform: string, from: string, to: string) {
 		fs.copySync(from.toString(), path.join(this.options.to, this.sysdir(), to + '.wav'), { overwrite: true });
-		return [to + '.wav'];
+		return { files: [to + '.wav'], sizes: [1] };
 	}
 
 	async copyVideo(platform: string, from: string, to: string) {
 		fs.ensureDirSync(path.join(this.options.to, this.sysdir(), path.dirname(to)));
 		await convert(from, path.join(this.options.to, this.sysdir(), to + '.wmv'), this.options.wmv);
-		return [to + '.wmv'];
+		return { files: [to + '.wmv'], sizes: [1] };
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -485,11 +485,12 @@ async function exportKhaProject(options: Options): Promise<string> {
 		return fallback;
 	}
 
-	let files: {name: string, files: string[], type: string, inputs: any[], outputs: any[], uniforms: any[], types: any[]}[] = [];
+	let files: {name: string, files: string[], file_sizes: number[], type: string, inputs: any[], outputs: any[], uniforms: any[], types: any[]}[] = [];
 	for (let asset of assets) {
 		let file: any = {
 			name: fixName(asset.name),
 			files: asset.files,
+			file_sizes: asset.file_sizes,
 			type: asset.type
 		};
 		if (file.type === 'image') {
@@ -505,6 +506,7 @@ async function exportKhaProject(options: Options): Promise<string> {
 		files.push({
 			name: fixName(shader.name),
 			files: shader.files === null ? oldShader.files : shader.files,
+			file_sizes: [1],
 			type: 'shader',
 			inputs: shader.inputs === null ? oldShader.inputs : shader.inputs,
 			outputs: shader.outputs === null ? oldShader.outputs : shader.outputs,


### PR DESCRIPTION
This PR adds file sizes to the `files.json` file to give this information to the `AssetsBuilder` and `Assets` lists in Kha.

So far, this is implemented for the HTML5 target and stubbed for the remaining targets.

Basically, it changes the `file` entry in `files.json` from:

```json
{
	"name": "lenna",
	"files": [
		"lenna.png"
	],
	"type": "image",
	"original_width": 512,
	"original_height": 512
},
```

to:

```json
{
	"name": "lenna",
	"files": [
		"lenna.png"
	],
	"file_sizes": [
		556211
	],
	"type": "image",
	"original_width": 512,
	"original_height": 512
},
```

Adding a new `file_sizes` entry was done (instead of modifying the type of the `files` entry) in order to prevent breakage across targets which expect a certain format of the description.

I didn't update the compiled `.js` files because I couldn't compile any typescript without completely messing up the existing typescript config, so the typescript files will have to be compiled before these changes make it into production.

This PR should be merged as a requirement to Kode/Kha#1133 which makes use of the additional field to improve asset loading metrics.