### PR TITLE
fix hxproj generation: escape additional parameters string 

### DIFF
--- a/out/HaxeProject.js
+++ b/out/HaxeProject.js
@@ -10,6 +10,18 @@ function copyAndReplace(from, to, names, values) {
     }
     fs.writeFileSync(to, data, { encoding: 'utf8' });
 }
+function escapeXml(s) {
+    return s.replace(/[<>&'"]/g, c => {
+        switch (c) {
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '&': return '&amp;';
+            case '\'': return '&apos;';
+            case '"': return '&quot;';
+            default: throw "unreachable code";
+        }
+    });
+}
 function IntelliJ(projectdir, options) {
     let indir = path.join(__dirname, '..', 'Data', 'intellij');
     let outdir = path.join(projectdir, options.safeName + '-' + options.system + '-intellij');
@@ -286,7 +298,7 @@ function FlashDevelop(projectdir, options) {
     }
     def += '-D kha_output=&quot;' + path.resolve(path.join(projectdir, options.to)) + '&quot;&#xA;';
     for (let param of options.parameters) {
-        def += param + '&#xA;';
+        def += escapeXml(param) + '&#xA;';
     }
     let project = {
         n: 'project',

--- a/src/HaxeProject.ts
+++ b/src/HaxeProject.ts
@@ -11,6 +11,20 @@ function copyAndReplace(from: string, to: string, names: string[], values: strin
 	fs.writeFileSync(to, data, { encoding: 'utf8' });
 }
 
+function escapeXml(s: string) {
+    return s.replace(/[<>&'"]/g, c=>{
+			switch (c) {
+				case '<': return '&lt;';
+				case '>': return '&gt;';
+				case '&': return '&amp;';
+				case '\'': return '&apos;';
+				case '"': return '&quot;';
+				default: throw "unreachable code";
+			}
+		}
+    );
+}
+
 function IntelliJ(projectdir: string, options: any) {
 	let indir = path.join(__dirname, '..', 'Data', 'intellij');
 	let outdir = path.join(projectdir, options.safeName + '-' + options.system + '-intellij');
@@ -309,7 +323,7 @@ function FlashDevelop(projectdir: string, options: any) {
 	}
 	def += '-D kha_output=&quot;' + path.resolve(path.join(projectdir, options.to)) + '&quot;&#xA;';
 	for (let param of options.parameters) {
-		def += param + '&#xA;';
+		def += escapeXml(param) + '&#xA;';
 	}
 
 	let project = {


### PR DESCRIPTION
this line in khafile.js was making khamake generate invalid .hxproj
```
project.addParameter('--macro keep("sys.io.File")');
``` 
`"` symbol was not escaped and resulting xml was invalid.