### PR TITLE
Support electron v5+

### DIFF
--- a/Data/debug-html5/electron.js
+++ b/Data/debug-html5/electron.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const electron = require('electron');
-const app = electron.app; 
+const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 
 var mainWindow = null;
@@ -22,7 +22,13 @@ app.on('window-all-closed', function () {
 });
 
 app.on('ready', function () {
-	mainWindow = new BrowserWindow({width: {Width}, height: {Height}, show: false, useContentSize: true, autoHideMenuBar: true});
+	mainWindow = new BrowserWindow({
+		width: {Width}, height: {Height},
+		show: false, useContentSize: true, autoHideMenuBar: true,
+		webPreferences: {
+			nodeIntegration: true
+		}
+	});
 	mainWindow.loadURL('file://' + __dirname + '/index.html');
 	mainWindow.on('closed', function() {
 		mainWindow = null;


### PR DESCRIPTION
> As of version 5, the default for nodeIntegration changed from true to false. You can enable it when creating the Browser Window