### PR TITLE
respect '-main' parameter in FlashDevelop project

### DIFF
--- a/out/HaxeProject.js
+++ b/out/HaxeProject.js
@@ -297,8 +297,15 @@ function FlashDevelop(projectdir, options) {
         def += '-net-std ' + path.relative(projectdir, path.join(options.haxeDirectory, 'netlib')) + '&#xA;';
     }
     def += '-D kha_output=&quot;' + path.resolve(path.join(projectdir, options.to)) + '&quot;&#xA;';
+    let mainClass = "Main";
     for (let param of options.parameters) {
-        def += escapeXml(param) + '&#xA;';
+        const mainRe = /-main\s+([^\s]+)/.exec(param);
+        if (mainRe) {
+            mainClass = mainRe[1];
+        }
+        else {
+            def += escapeXml(param) + '&#xA;';
+        }
     }
     let project = {
         n: 'project',
@@ -337,7 +344,7 @@ function FlashDevelop(projectdir, options) {
                     },
                     {
                         n: 'option',
-                        mainClass: 'Main'
+                        mainClass: mainClass
                     },
                     {
                         n: 'option',

--- a/src/HaxeProject.ts
+++ b/src/HaxeProject.ts
@@ -322,7 +322,7 @@ function FlashDevelop(projectdir: string, options: any) {
 		def += '-net-std ' + path.relative(projectdir, path.join(options.haxeDirectory, 'netlib')) + '&#xA;';
 	}
 	def += '-D kha_output=&quot;' + path.resolve(path.join(projectdir, options.to)) + '&quot;&#xA;';
-	let mainClass = "Main";
+	let mainClass = 'Main';
 	for (let param of options.parameters) {
 		const mainRe = /-main\s+([^\s]+)/.exec(param);
 		if (mainRe) {

--- a/src/HaxeProject.ts
+++ b/src/HaxeProject.ts
@@ -322,8 +322,15 @@ function FlashDevelop(projectdir: string, options: any) {
 		def += '-net-std ' + path.relative(projectdir, path.join(options.haxeDirectory, 'netlib')) + '&#xA;';
 	}
 	def += '-D kha_output=&quot;' + path.resolve(path.join(projectdir, options.to)) + '&quot;&#xA;';
+	let mainClass = "Main";
 	for (let param of options.parameters) {
-		def += escapeXml(param) + '&#xA;';
+		const mainRe = /-main\s+([^\s]+)/.exec(param);
+		if (mainRe) {
+			mainClass = mainRe[1];
+		}
+		else {
+			def += escapeXml(param) + '&#xA;';
+		}
 	}
 
 	let project = {
@@ -362,7 +369,7 @@ function FlashDevelop(projectdir: string, options: any) {
 					},
 					{
 						n: 'option',
-						mainClass: 'Main'
+						mainClass: mainClass
 					},
 					{
 						n: 'option',


### PR DESCRIPTION
Fix FlashDevelop project generation if main class is specified in khafile:
```
project.addParameter('-main SomeClassPath');
```
Hxml is already generated correctly for that case.