### PR TITLE
Fix html5 exporter when not using mp4 audio

### DIFF
--- a/out/Exporters/Html5Exporter.js
+++ b/out/Exporters/Html5Exporter.js
@@ -178,10 +178,12 @@ class Html5Exporter extends KhaExporter_1.KhaExporter {
         let mp3_size = 0;
         if (!this.isADebugTarget()) {
             mp4 = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.aac);
-            mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
+            if(mp4) {
+				mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
+			}
             if (!mp4) {
                 mp3 = await Converter_1.convert(from, path.join(this.options.to, this.sysdir(), to + '.mp3'), this.options.mp3);
-                mp3_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
+                mp3_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp3'))).size;
             }
         }
         let files = [];

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -217,7 +217,7 @@ export class Html5Exporter extends KhaExporter {
 		let mp3_size = 0;
 		if (!this.isADebugTarget()) {
 			mp4 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.aac);
-			if(mp4) {
+			if (mp4) {
 				mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
 			}
 			if (!mp4) {

--- a/src/Exporters/Html5Exporter.ts
+++ b/src/Exporters/Html5Exporter.ts
@@ -217,10 +217,12 @@ export class Html5Exporter extends KhaExporter {
 		let mp3_size = 0;
 		if (!this.isADebugTarget()) {
 			mp4 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp4'), this.options.aac);
-			mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
+			if(mp4) {
+				mp4_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
+			}
 			if (!mp4) {
 				mp3 = await convert(from, path.join(this.options.to, this.sysdir(), to + '.mp3'), this.options.mp3);
-				mp3_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp4'))).size;
+				mp3_size = (await fs.stat(path.join(this.options.to, this.sysdir(), to + '.mp3'))).size;
 			}
 		}
 		let files: string[] = [];


### PR DESCRIPTION
Not crash compilation when not using mp4 audio 