### PR TITLE
Add quiet flag (like silent but still prints error messages)

### DIFF
--- a/out/khamake.js
+++ b/out/khamake.js
@@ -212,6 +212,11 @@ let options = [
         value: false
     },
     {
+        full: 'quiet',
+        description: 'Quiet mode. Like silent mode but prints error messages.',
+        value: false
+    },
+    {
         full: 'watch',
         short: 'w',
         description: 'Watch files and recompile on change.',

--- a/out/log.js
+++ b/out/log.js
@@ -21,9 +21,11 @@ function set(log) {
     myError = log.error;
 }
 exports.set = set;
-function silent() {
+function silent(showErrors = false) {
     myInfo = function () { };
-    myError = function () { };
+    if (!showErrors) {
+        myError = function () { };
+    }
 }
 exports.silent = silent;
 function info(text, newline = true) {

--- a/out/main.js
+++ b/out/main.js
@@ -596,6 +596,9 @@ async function run(options, loglog) {
     else {
         log.set(loglog);
     }
+    if (options.quiet) {
+        log.silent(true);
+    }
     if (!options.kha) {
         let p = path.join(__dirname, '..', '..', '..');
         if (fs.existsSync(p) && fs.statSync(p).isDirectory()) {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -30,6 +30,7 @@ export class Options {
 	port: string;
 	debug: boolean;
 	silent: boolean;
+	quiet: boolean;
 	watch: boolean;
 	glsl2: boolean;
 	shaderversion: string;

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -213,6 +213,11 @@ let options: Array<any> = [
 		value: false
 	},
 	{
+		full: 'quiet',
+		description: 'Quiet mode. Like silent mode but prints error messages.',
+		value: false
+	},
+	{
 		full: 'watch',
 		short: 'w',
 		description: 'Watch files and recompile on change.',

--- a/src/log.ts
+++ b/src/log.ts
@@ -21,9 +21,11 @@ export function set(log: {info: (text: string, newline: boolean) => void, error:
 	myError = log.error;
 }
 
-export function silent() {
+export function silent(showErrors: boolean = false) {
 	myInfo = function () {};
-	myError = function () {};
+	if (!showErrors) {
+		myError = function () {};
+	}
 }
 
 export function info(text: string, newline: boolean = true) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -665,6 +665,10 @@ export async function run(options: Options, loglog: any): Promise<string> {
 		log.set(loglog);
 	}
 
+	if (options.quiet) {
+		log.silent(true);
+	}
+
 	if (!options.kha) {
 		let p = path.join(__dirname, '..', '..', '..');
 		if (fs.existsSync(p) && fs.statSync(p).isDirectory()) {


### PR DESCRIPTION
When running khamake with `--quiet`, only error messages are shown (`--silent` does not print anything).

If "quiet" is too unobvious as a parameter name, feel free to change it :)