### PR TITLE
Fix addLibrary infinite loop when haxelib has circular dependencies

### DIFF
--- a/out/Project.js
+++ b/out/Project.js
@@ -173,6 +173,11 @@ class Project {
         let libInfo = findLibraryDirectory(library);
         let dir = libInfo.libpath;
         if (dir !== '') {
+            for (let elem of this.libraries)
+            {
+                if (elem.libroot == libInfo.libroot)
+                    return '';
+            }
             this.libraries.push({
                 libpath: dir,
                 libroot: libInfo.libroot

--- a/out/Project.js
+++ b/out/Project.js
@@ -173,9 +173,8 @@ class Project {
         let libInfo = findLibraryDirectory(library);
         let dir = libInfo.libpath;
         if (dir !== '') {
-            for (let elem of this.libraries)
-            {
-                if (elem.libroot == libInfo.libroot)
+            for (let elem of this.libraries) {
+                if (elem.libroot === libInfo.libroot)
                     return '';
             }
             this.libraries.push({

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -216,6 +216,10 @@ export class Project {
 		let dir = libInfo.libpath;
 
 		if (dir !== '') {
+            for (let elem of this.libraries) {
+                if (elem.libroot === libInfo.libroot)
+                    return '';
+            }
 			this.libraries.push({
 				libpath: dir,
 				libroot: libInfo.libroot

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -216,10 +216,10 @@ export class Project {
 		let dir = libInfo.libpath;
 
 		if (dir !== '') {
-            for (let elem of this.libraries) {
-                if (elem.libroot === libInfo.libroot)
-                    return '';
-            }
+			for (let elem of this.libraries) {
+				if (elem.libroot === libInfo.libroot)
+					return '';
+			}
 			this.libraries.push({
 				libpath: dir,
 				libroot: libInfo.libroot


### PR DESCRIPTION
Some haxelibs have circular dependencies, e.g. munit -> mcover -> munit, causing addLibrary to loop forever.