### PR TITLE
Make it possible to run khamake from anywhere if you npm install -g

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../khamake');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Kha build tool",
   "main": "khamake.js",
+  "bin": {
+    "khamake": "./bin/index.js"
+  },
   "scripts": {
     "build": "tsc -p ."
   },

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,3 @@
+Build tool for [Kha](https://github.com/Kode/Kha) projects.
+
+To use from any directory by just typing `khamake` on the command line, cd into this directory and run `npm install -g`.


### PR DESCRIPTION
This simplifies the process of running khamake from anywhere -- instead of having to make a batch file or whatever like it currently says [in the wiki](https://github.com/Kode/Kha/wiki/Getting-Started#git), you can just run npm install -g from inside the khamake folder. Then `khamake` is available as a binary command from anywhere on the command line