### PR TITLE
Prevent get version information on unversioned kha

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -633,7 +633,8 @@ function runProject(options: any, name: string): Promise<void> {
 export let api = 2;
 
 function findKhaVersion(dir: string): string {
-	if (fs.existsSync(path.join(dir, '.git'))) {
+	let p = path.join(dir, '.git');
+	if (fs.existsSync(p) && fs.statSync(p).isDirectory() ) {
 		let gitVersion = 'git-error';
 		try {
 			const output = child_process.spawnSync('git', ['rev-parse', 'HEAD'], {encoding: 'utf8', cwd: dir}).output;


### PR DESCRIPTION
Prevents printing broken version information if Kha/.git exists but is a file not a directory.


`Using Kha (fatal: n, fatal: not a git repository: /home/user/Kha/../.git/modules/Kha) from 
/home/user/Kha`
→
`Using Kha (unversioned) from /home/user/Kha`