### PR TITLE
Enables contextIsolation for Electron < 12

### DIFF
--- a/Data/debug-html5/electron.js
+++ b/Data/debug-html5/electron.js
@@ -29,6 +29,7 @@ app.on('ready', function () {
 		show: false, useContentSize: true, autoHideMenuBar: true,
 		icon: app.getAppPath() + '/favicon' + {ext},
 		webPreferences: {
+			contextIsolation: true,
 			preload: path.join(app.getAppPath(), 'preload.js')
 		}
 	});


### PR DESCRIPTION
Is needed to run `debug-html5` for Electron versions prior to 12.