### PR TITLE
Add missing meta tag used to get canvas size

### DIFF
--- a/Data/debug-html5/index.html
+++ b/Data/debug-html5/index.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8"/>
 	<meta http-equiv="Content-Security-Policy" content="script-src 'self';">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, minimal-ui">
 	<title>{Name}</title>
 	<style>
 		html, body, canvas, div {


### PR DESCRIPTION
The new meta tag is only present in html5 but not in debug-html5