### PR TITLE
Fix nested calls to addProject()

### DIFF
--- a/out/Project.js
+++ b/out/Project.js
@@ -63,6 +63,9 @@ class Project {
         return this.safeName;
     }
     async addProject(projectDir) {
+        if (!path.isAbsolute(projectDir)) {
+            projectDir = path.join(this.scriptdir, projectDir);
+        }
         let project = await ProjectFile_1.loadProject(projectDir, 'khafile.js', Project.platform);
         this.assetMatchers = this.assetMatchers.concat(project.assetMatchers);
         this.sources = this.sources.concat(project.sources);

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -92,6 +92,9 @@ export class Project {
 	}
 
 	async addProject(projectDir: string) {
+		if (!path.isAbsolute(projectDir)) {
+			projectDir = path.join(this.scriptdir, projectDir);
+		}
 		let project = await loadProject(projectDir, 'khafile.js', Project.platform);
 		this.assetMatchers = this.assetMatchers.concat(project.assetMatchers);
 		this.sources = this.sources.concat(project.sources);


### PR DESCRIPTION
Fixes https://github.com/Kode/khamake/issues/146. Relative subproject paths are now recursively made relative to the current project.