### PR TITLE
Still retrieve git-version if using gitdir [no more ¯\_(ツ)_/¯]

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -570,7 +570,17 @@ function runProject(options, name) {
 exports.api = 2;
 function findKhaVersion(dir) {
     let p = path.join(dir, '.git');
-    if (fs.existsSync(p) && fs.statSync(p).isDirectory()) {
+    let hasGitInfo = false;
+    if (fs.existsSync(p)) {
+        let stat = fs.statSync(p);
+        hasGitInfo = stat.isDirectory();
+        // otherwise git might not utilize an in-place directory
+        if (!hasGitInfo) {
+            let contents = fs.readFileSync(p).toString('utf8', 0, 7);
+            hasGitInfo = contents === 'gitdir:';
+        }
+    }
+    if (hasGitInfo) {
         let gitVersion = 'git-error';
         try {
             const output = child_process.spawnSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8', cwd: dir }).output;

--- a/src/main.ts
+++ b/src/main.ts
@@ -635,7 +635,20 @@ export let api = 2;
 
 function findKhaVersion(dir: string): string {
 	let p = path.join(dir, '.git');
-	if (fs.existsSync(p) && fs.statSync(p).isDirectory() ) {
+	let hasGitInfo = false;
+
+	if (fs.existsSync(p)) {
+		let stat = fs.statSync(p);
+		hasGitInfo = stat.isDirectory();
+
+		// otherwise git might not utilize an in-place directory
+		if (!hasGitInfo) {
+			let contents = fs.readFileSync(p).toString('utf8', 0, 7);
+			hasGitInfo = contents === 'gitdir:';
+		}
+	}
+
+	if (hasGitInfo) {
 		let gitVersion = 'git-error';
 		try {
 			const output = child_process.spawnSync('git', ['rev-parse', 'HEAD'], {encoding: 'utf8', cwd: dir}).output;


### PR DESCRIPTION
Support an alternative git structure that uses `gitdir:` instead of a directory with git information.

This fixes an issue, for me at least, where Khamake was only printing out  `¯\_(ツ)_/¯` for the version instead of the actual git version.
I'm not sure if anything about git changed recently, but my project doesn't utilize git folders it just contains information in the .git file of where the relative git directory is.