### PR TITLE
Add onFailure callback

### DIFF
--- a/out/ProjectFile.js
+++ b/out/ProjectFile.js
@@ -12,7 +12,8 @@ exports.Callbacks = {
     postHaxeCompilation: [() => { }],
     postHaxeRecompilation: [() => { }],
     postCppCompilation: [() => { }],
-    postAssetReexporting: [(filePath) => { }]
+    postAssetReexporting: [(filePath) => { }],
+    onFailure: [(error) => { }]
 };
 async function loadProject(from, projectfile, platform) {
     return new Promise((resolve, reject) => {
@@ -29,6 +30,7 @@ async function loadProject(from, projectfile, platform) {
                 postHaxeRecompilation: () => { },
                 postCppCompilation: () => { },
                 postAssetReexporting: (filePath) => { },
+                onFailure: (error) => { }
             };
             let resolver = (project) => {
                 resolved = true;
@@ -39,6 +41,7 @@ async function loadProject(from, projectfile, platform) {
                 exports.Callbacks.postHaxeRecompilation.push(callbacks.postHaxeRecompilation);
                 exports.Callbacks.postCppCompilation.push(callbacks.postCppCompilation);
                 exports.Callbacks.postAssetReexporting.push(callbacks.postAssetReexporting);
+                exports.Callbacks.onFailure.push(callbacks.onFailure);
                 resolve(project);
             };
             process.on('exit', (code) => {

--- a/out/khamake.js
+++ b/out/khamake.js
@@ -5,6 +5,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const os = require("os");
 const path = require("path");
+const ProjectFile_1 = require("./ProjectFile");
 const GraphicsApi_1 = require("./GraphicsApi");
 const Architecture_1 = require("./Architecture");
 const AudioApi_1 = require("./AudioApi");
@@ -373,6 +374,9 @@ async function runKhamake() {
     }
     catch (error) {
         console.log(error);
+        for (let callback of ProjectFile_1.Callbacks.onFailure) {
+            callback(error);
+        }
         process.exit(1);
     }
 }

--- a/out/main.js
+++ b/out/main.js
@@ -728,6 +728,9 @@ async function run(options, loglog) {
         name = await exportProject(options);
     }
     catch (err) {
+        for (let callback of ProjectFile_1.Callbacks.onFailure) {
+            callback(err);
+        }
         process.exit(1);
     }
     if ((options.target === Platform_1.Platform.Linux || options.target === Platform_1.Platform.FreeBSD) && options.run) {

--- a/src/ProjectFile.ts
+++ b/src/ProjectFile.ts
@@ -11,7 +11,8 @@ export let Callbacks = {
 	postHaxeCompilation:   [() => {}],
 	postHaxeRecompilation: [() => {}],
 	postCppCompilation:    [() => {}],
-	postAssetReexporting:  [(filePath: string) => {}]
+	postAssetReexporting:  [(filePath: string) => {}],
+	onFailure:             [(error: any) => {}]
 };
 
 export async function loadProject(from: string, projectfile: string, platform: string): Promise<Project> {
@@ -30,6 +31,7 @@ export async function loadProject(from: string, projectfile: string, platform: s
 				postHaxeRecompilation: () => {},
 				postCppCompilation:    () => {},
 				postAssetReexporting:  (filePath: string) => {},
+				onFailure:             (error: any) => {}
 			};
 			let resolver = (project: Project) => {
 				resolved = true;
@@ -40,6 +42,7 @@ export async function loadProject(from: string, projectfile: string, platform: s
 				Callbacks.postHaxeRecompilation.push(callbacks.postHaxeRecompilation);
 				Callbacks.postCppCompilation.push(callbacks.postCppCompilation);
 				Callbacks.postAssetReexporting.push(callbacks.postAssetReexporting);
+				Callbacks.onFailure.push(callbacks.onFailure);
 				resolve(project);
 			};
 

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -4,6 +4,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
+import {Callbacks} from './ProjectFile';
 import {GraphicsApi} from './GraphicsApi';
 import {Architecture} from './Architecture';
 import {AudioApi} from './AudioApi';
@@ -379,6 +380,9 @@ async function runKhamake() {
 	}
 	catch (error) {
 		console.log(error);
+		for (let callback of Callbacks.onFailure) {
+			callback(error);
+		}
 		process.exit(1);
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -822,6 +822,9 @@ export async function run(options: Options, loglog: any): Promise<string> {
 		name = await exportProject(options);
 	}
 	catch (err) {
+		for (let callback of Callbacks.onFailure) {
+			callback(err);
+		}
 		process.exit(1);
 	}
 


### PR DESCRIPTION
There's currently no way to react to build failures from within the Khafile, but if (for example) the pre/post Haxe compilation callbacks are used and there is a compilation error, it can be important to do some cleanup that would otherwise be called in the post compilation callback. This PR adds a new callback `onFailure` (please suggest a better name if it doesn't fit well) that is called in most cases in which the Khamake process exits with code 1.

---

Btw (just for your information), running `tsc` in the project root to generate the .js files will also generate three seemingly unrelated lines of code, two of those were just removed in https://github.com/Kode/khamake/commit/27cf0b1bea74c6573d146b6f26bfaaf8cd11631f. I'm not sure if they should be included or not. They aren't related to my changes, so they are not part of this PR (and discarding them doesn't lead to problems).

Those lines are
`exports.HaxeCompiler = void 0;` in HaxeCompiler.js
`exports.close = exports.run = exports.api = void 0;` in main.js
`exports.Options = void 0;` in Options.js