### PR TITLE
Allow to run --watch --server

### DIFF
--- a/out/khamake.js
+++ b/out/khamake.js
@@ -412,6 +412,8 @@ else if (parsedOptions.server) {
         }
     });
     server.listen(parsedOptions.port);
+    if (parsedOptions.watch)
+        runKhamake();
 }
 else {
     runKhamake();

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -423,6 +423,7 @@ else if (parsedOptions.server) {
 		}
 	});
 	server.listen(parsedOptions.port);
+	if (parsedOptions.watch) runKhamake();
 }
 else {
 	runKhamake();


### PR DESCRIPTION
So you can get working http/haxe servers with one command.
This makes things easier to maintain in vscode tasks and kill http/haxe/watcher servers at the end of debugging without zombie processes.
```json
{
	"name": "Debug",
	"request": "launch",
	"type": "pwa-node",
	"program": "${command:kha.findKha}/make",
	"args": ["html5", "--watch", "--server"],
	"killBehavior": "polite",
},
```