### PR TITLE
--parallelAssetConversion: fix value parsing

### DIFF
--- a/out/khamake.js
+++ b/out/khamake.js
@@ -328,6 +328,9 @@ for (let i = 2; i < args.length; ++i) {
                         if (option.full === 'target') {
                             targetIsDefault = false;
                         }
+                        else if (option.full === 'parallelAssetConversion') {
+                            parsedOptions[option.full] = parseInt(parsedOptions[option.full]);
+                        }
                     }
                     else {
                         parsedOptions[option.full] = true;

--- a/src/khamake.ts
+++ b/src/khamake.ts
@@ -336,6 +336,9 @@ for (let i = 2; i < args.length; ++i) {
 						if (option.full === 'target') {
 							targetIsDefault = false;
 						}
+						else if (option.full === 'parallelAssetConversion') {
+							parsedOptions[option.full] = parseInt(parsedOptions[option.full]);
+						}
 					}
 					else {
 						parsedOptions[option.full] = true;


### PR DESCRIPTION
The value of the `--parallelAssetConversion` option was treated as a string, which did not work for the `=== -1` comparison that enables the automatic processes amount.

I'm not sure why it worked for positive values before since they were strings as well. Perhaps `Throttle.all()` (called by the assets and shader conversion code) can convert strings, but we shouldn't rely on that.