### PR TITLE
Do not check relative lib path first

### DIFF
--- a/out/main.js
+++ b/out/main.js
@@ -191,6 +191,7 @@ async function exportProjectFiles(name, resourceDir, options, exporter, kore, ko
                 log.error('Error.');
             }
             process.exit(1);
+            return name;
         }
     }
     else if (options.haxe !== '' && korehl && !options.noproject) {
@@ -228,6 +229,7 @@ async function exportProjectFiles(name, resourceDir, options, exporter, kore, ko
                 log.error('Error.');
             }
             process.exit(1);
+            return name;
         }
     }
     else {

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -223,11 +223,6 @@ export class Project {
 				return { libpath: name, libroot: name };
 			}
 
-			// check relative path
-			if (fs.existsSync(path.resolve(name))) {
-				return { libpath: name, libroot: name };
-			}
-
 			// Tries to load the default library from inside the kha project.
 			// e.g. 'Libraries/wyngine'
 			let libpath = path.join(self.scriptdir, self.localLibraryPath, name);
@@ -248,7 +243,11 @@ export class Project {
 			}
 			if (fs.existsSync(libpath) && fs.statSync(libpath).isDirectory()) {
 				if (fs.existsSync(path.join(libpath, '.dev'))) {
-					return { libpath: fs.readFileSync(path.join(libpath, '.dev'), 'utf8'), libroot: libpath };
+					libpath = fs.readFileSync(path.join(libpath, '.dev'), 'utf8');
+					if (!path.isAbsolute(libpath)) {
+						libpath = path.resolve(libpath);
+					}
+					return { libpath: libpath, libroot: libpath };
 				}
 				else if (fs.existsSync(path.join(libpath, '.current'))) {
 					// Get the latest version of the haxelib path,
@@ -256,6 +255,11 @@ export class Project {
 					let current = fs.readFileSync(path.join(libpath, '.current'), 'utf8');
 					return { libpath: path.join(libpath, current.replace(/\./g, ',')), libroot: libpath };
 				}
+			}
+			// check relative path
+			if (fs.existsSync(path.resolve(name))) {
+				let libpath = path.resolve(name);
+				return { libpath: libpath, libroot: libpath };
 			}
 			// Show error if library isn't found in Libraries or haxelib folder
 			log.error('Error: Library ' + name + ' not found.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,6 +220,7 @@ async function exportProjectFiles(name: string, resourceDir: string, options: Op
 				log.error('Error.');
 			}
 			process.exit(1);
+			return name;
 		}
 	}
 	else if (options.haxe !== '' && korehl && !options.noproject) {
@@ -258,6 +259,7 @@ async function exportProjectFiles(name: string, resourceDir: string, options: Op
 				log.error('Error.');
 			}
 			process.exit(1);
+			return name;
 		}
 	}
 	else {
@@ -564,7 +566,7 @@ async function exportKhaProject(options: Options): Promise<string> {
 	for (let callback of Callbacks.preHaxeCompilation) {
 		callback();
 	}
-	
+
 	return await exportProjectFiles(project.name, path.join(options.to, exporter.sysdir() + '-resources'), options, exporter, kore, korehl, project.icon,
 		project.libraries, project.targetOptions, project.defines, project.cdefines, project.cflags, project.cppflags, project.stackSize, project.version, project.id);
 }
@@ -778,7 +780,7 @@ export async function run(options: Options, loglog: any): Promise<string> {
 		}
 		throw err;
 	}
-	
+
 	for (let callback of Callbacks.postBuild) {
 		callback();
 	}


### PR DESCRIPTION
I have symlink to my lib in project root only for faster navigation to that lib folder, but khamake adds symlink as library path to generated hxml.
So it breaks ide support in lib files.

I moved `project/libName` search below `project/Libraries/libName` and `haxelib path libName` searches.
Not sure if this resolving is documented and should still exist.