### PR TITLE
Fix haxelibs with classPath

### DIFF
--- a/out/HaxeProject.js
+++ b/out/HaxeProject.js
@@ -112,12 +112,14 @@ function hxml(projectdir, options) {
             data += unique('-cp ' + path.relative(projectdir, path.resolve(options.from, options.sources[i])) + '\n'); // from.resolve('build').relativize(from.resolve(this.sources[i])).toString());
         }
     }
-    for (let i = 0; i < options.libraries.length; ++i) {
-        if (path.isAbsolute(options.libraries[i].libpath)) {
-            data += unique('-cp ' + options.libraries[i].libpath + '\n');
+    for (const lib of options.libraries) {
+        if (lib.classPathIsAdded)
+            continue;
+        if (path.isAbsolute(lib.libpath)) {
+            data += unique('-cp ' + lib.libpath + '\n');
         }
         else {
-            data += unique('-cp ' + path.relative(projectdir, path.resolve(options.from, options.libraries[i].libpath)) + '\n'); // from.resolve('build').relativize(from.resolve(this.sources[i])).toString());
+            data += unique('-cp ' + path.relative(projectdir, path.resolve(options.from, lib.libpath)) + '\n'); // from.resolve('build').relativize(from.resolve(this.sources[i])).toString());
         }
     }
     for (let d in options.defines) {

--- a/out/Project.js
+++ b/out/Project.js
@@ -7,6 +7,13 @@ const path = require("path");
 const log = require("./log");
 const ProjectFile_1 = require("./ProjectFile");
 class Library {
+    constructor() {
+        /**
+         * If haxelib `classPath` is specified,
+         * we don't add `libpath` as `-cp` to `hxml`.
+        */
+        this.classPathIsAdded = false;
+    }
 }
 exports.Library = Library;
 class Target {
@@ -231,17 +238,18 @@ class Project {
                 if (elem.libroot === libInfo.libroot)
                     return '';
             }
-            this.libraries.push({
+            const lib = {
                 libpath: dir,
                 libroot: libInfo.libroot
-            });
+            };
+            this.libraries.push(lib);
             // If this is a haxelib library, there must be a haxelib.json
             if (fs.existsSync(path.join(dir, 'haxelib.json'))) {
                 let options = JSON.parse(fs.readFileSync(path.join(dir, 'haxelib.json'), 'utf8'));
                 // If there is a classPath value, add that directory to be loaded.
                 // Otherwise, just load the current path.
                 if (options.classPath) {
-                    // TODO find an example haxelib that has a classPath value
+                    lib.classPathIsAdded = true;
                     this.sources.push(path.join(dir, options.classPath));
                 }
                 else {

--- a/src/HaxeProject.ts
+++ b/src/HaxeProject.ts
@@ -110,7 +110,7 @@ function hxml(projectdir: string, options: any) {
 		if (lines.indexOf(line) === -1) {
 			lines.push(line);
 			return line;
-		}		
+		}
 		return '';
 	}
 
@@ -122,12 +122,13 @@ function hxml(projectdir: string, options: any) {
 			data += unique('-cp ' + path.relative(projectdir, path.resolve(options.from, options.sources[i])) + '\n'); // from.resolve('build').relativize(from.resolve(this.sources[i])).toString());
 		}
 	}
-	for (let i = 0; i < options.libraries.length; ++i) {
-		if (path.isAbsolute(options.libraries[i].libpath)) {
-			data += unique('-cp ' + options.libraries[i].libpath + '\n');
+	for (const lib of options.libraries) {
+		if (lib.classPathIsAdded) continue
+		if (path.isAbsolute(lib.libpath)) {
+			data += unique('-cp ' + lib.libpath + '\n');
 		}
 		else {
-			data += unique('-cp ' + path.relative(projectdir, path.resolve(options.from, options.libraries[i].libpath)) + '\n'); // from.resolve('build').relativize(from.resolve(this.sources[i])).toString());
+			data += unique('-cp ' + path.relative(projectdir, path.resolve(options.from, lib.libpath)) + '\n'); // from.resolve('build').relativize(from.resolve(this.sources[i])).toString());
 		}
 	}
 	for (let d in options.defines) {
@@ -170,7 +171,7 @@ function hxml(projectdir: string, options: any) {
 
 	if (!options.parameters.some((param: string) => param.includes('-main '))) {
 		const entrypoint = options ? options.main ? options.main : 'Main' : 'Main';
-		data += unique('-main ' + entrypoint + '\n');	
+		data += unique('-main ' + entrypoint + '\n');
 	}
 
 	fs.outputFileSync(path.join(projectdir, 'project-' + options.system + '.hxml'), data);

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -7,6 +7,11 @@ import {loadProject} from './ProjectFile';
 export class Library {
 	libpath: string;
 	libroot: string;
+	/**
+	 * If haxelib `classPath` is specified,
+	 * we don't add `libpath` as `-cp` to `hxml`.
+	*/
+	classPathIsAdded? = false;
 }
 
 export class Target {
@@ -275,17 +280,18 @@ export class Project {
 				if (elem.libroot === libInfo.libroot)
 					return '';
 			}
-			this.libraries.push({
+			const lib:Library = {
 				libpath: dir,
 				libroot: libInfo.libroot
-			});
+			}
+			this.libraries.push(lib);
 			// If this is a haxelib library, there must be a haxelib.json
 			if (fs.existsSync(path.join(dir, 'haxelib.json'))) {
 				let options = JSON.parse(fs.readFileSync(path.join(dir, 'haxelib.json'), 'utf8'));
 				// If there is a classPath value, add that directory to be loaded.
 				// Otherwise, just load the current path.
 				if (options.classPath) {
-					// TODO find an example haxelib that has a classPath value
+					lib.classPathIsAdded = true
 					this.sources.push(path.join(dir, options.classPath));
 				}
 				else {


### PR DESCRIPTION
This removes from `build.hxml` paths like:
`-cp /Users/maxim/haxe/haxelib/mister-lobster/git`
And keeps only 
`-cp /Users/maxim/haxe/haxelib/mister-lobster/git/src`
If this library has `haxelib.json` with `classPath: "src/"`

It fixes completion in project for such libs.