### PR TITLE
Fix wait/connect race

### DIFF
--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -61,7 +61,9 @@ class HaxeCompiler {
                 this.scheduleCompile();
             });
             this.startCompilationServer();
-            this.triggerCompilationServer();
+            setTimeout(() => {
+                this.triggerCompilationServer();
+            }, 50);
         }
         else {
             try {

--- a/src/HaxeCompiler.ts
+++ b/src/HaxeCompiler.ts
@@ -71,7 +71,9 @@ export class HaxeCompiler {
 				this.scheduleCompile();
 			});
 			this.startCompilationServer();
-			this.triggerCompilationServer();
+			setTimeout(() => {
+				this.triggerCompilationServer();
+		}, 50);
 		}
 		else {
 			try {


### PR DESCRIPTION
Seems like --wait is not instant on macos, so wait after wait a bit. Also please update khamake submodule in Kha.