### PR TITLE
Another reexporting fix

### DIFF
--- a/out/AssetConverter.js
+++ b/out/AssetConverter.js
@@ -90,7 +90,10 @@ class AssetConverter {
                 let outPath = fileinfo.name;
                 // with subfolders
                 if (options.destination) {
-                    const from = path.resolve(options.baseDir, '..');
+                    // remove trailing slash
+                    const nameBaseDir = options.nameBaseDir.replace(/\/$/, '');
+                    const lastIndex = options.baseDir.lastIndexOf(nameBaseDir);
+                    const from = path.resolve(options.baseDir.substring(0, lastIndex));
                     outPath = AssetConverter.replacePattern(options.destination, fileinfo.name, fileinfo, options, from);
                 }
                 const ext = fileinfo.ext.toLowerCase();

--- a/src/AssetConverter.ts
+++ b/src/AssetConverter.ts
@@ -110,7 +110,10 @@ export class AssetConverter {
 				let outPath = fileinfo.name;
 				// with subfolders
 				if (options.destination) {
-					const from = path.resolve(options.baseDir, '..');
+					// remove trailing slash
+					const nameBaseDir = options.nameBaseDir.replace(/\/$/, '');
+					const lastIndex = options.baseDir.lastIndexOf(nameBaseDir)
+					const from = path.resolve(options.baseDir.substring(0, lastIndex));
 					outPath = AssetConverter.replacePattern(options.destination, fileinfo.name, fileinfo, options, from);
 				}
 				const ext = fileinfo.ext.toLowerCase();


### PR DESCRIPTION
Fix for case like this, when `nameBaseDir` is a subfolder
```js
project.addAssets('assets/_audio/(*.mp3|*.ogg|*.wav)', {
	nameBaseDir: 'assets/_audio',
	destination: '{dir}/{name}',
	name: '{dir}/{name}',
	quality: 0.99
});
```