### PR TITLE
Delay page reload to write js output first

### DIFF
--- a/out/HaxeCompiler.js
+++ b/out/HaxeCompiler.js
@@ -178,9 +178,11 @@ class HaxeCompiler {
                     process.stdout.write('\x1Bc');
                     log.info('Haxe compile end.');
                     if (this.isLiveReload) {
-                        this.wsClients.forEach(client => {
-                            client.send(JSON.stringify({}));
-                        });
+                        setTimeout(() => {
+                            this.wsClients.forEach(client => {
+                                client.send(JSON.stringify({}));
+                            });
+                        }, 200);
                     }
                     for (let callback of ProjectFile_1.Callbacks.postHaxeRecompilation) {
                         callback();
@@ -217,14 +219,6 @@ class HaxeCompiler {
                 }
             });
         });
-    }
-    static spinRename(from, to) {
-        for (;;) {
-            if (fs.existsSync(from)) {
-                fs.renameSync(from, to);
-                return;
-            }
-        }
     }
 }
 exports.HaxeCompiler = HaxeCompiler;

--- a/src/HaxeCompiler.ts
+++ b/src/HaxeCompiler.ts
@@ -198,9 +198,11 @@ export class HaxeCompiler {
 					process.stdout.write('\x1Bc');
 					log.info('Haxe compile end.');
 					if (this.isLiveReload) {
-						this.wsClients.forEach(client => {
-							client.send(JSON.stringify({}));
-						});
+						setTimeout(() => {
+							this.wsClients.forEach(client => {
+								client.send(JSON.stringify({}));
+							});
+						}, 200);
 					}
 					for (let callback of Callbacks.postHaxeRecompilation) {
 						callback();
@@ -239,14 +241,5 @@ export class HaxeCompiler {
 				}
 			});
 		});
-	}
-
-	private static spinRename(from: string, to: string): void {
-		for (; ; ) {
-			if (fs.existsSync(from)) {
-				fs.renameSync(from, to);
-				return;
-			}
-		}
 	}
 }


### PR DESCRIPTION
Page reload can happen too early for hard drives when you have big js file and http server returns only part of js file with syntax error, so you need to re-reload page after live reload to fix error. So i just added 200ms delay since there is no much events about when file writing is completed.

Maybe this is node-static bug when it does not return full file, not really sure.

I even tried smarter approach with opening file first and checking if write is complete, and this detects if file is not fully written sometimes, but still can report good file while http server still returns only a broken js part.

```typescript
isJsFileFullyWritten(filePath: string): boolean {
    const stats = fs.statSync(filePath);
    const fileSize = stats.size;
    // Only read the last 300 characters (or entire file if smaller)
    const readSize = Math.min(300, fileSize);
    const buffer = Buffer.alloc(readSize);
    const fd = fs.openSync(filePath, 'r');
    // Read the last portion of the file
    fs.readSync(fd, buffer, 0, readSize, fileSize - readSize);
    fs.closeSync(fd);
    const endContent = buffer.toString('utf8');
    console.log("is file full: ", endContent.includes('})(typeof') || endContent.includes('//# sourceMappingURL'));
    console.log(endContent);
    return endContent.includes('})(typeof')  || endContent.includes('//# sourceMappingURL');
  }

```